### PR TITLE
(fix)opencode: harden agent permissions with catch-all deny and git add wildcard

### DIFF
--- a/.opencode/agents/build.md
+++ b/.opencode/agents/build.md
@@ -15,6 +15,7 @@ permission:
     "git log*": allow
     "git status": allow
     "git add": allow
+    "git add *": allow
     "git checkout": allow
     "git branch": allow
     "git commit": allow
@@ -26,6 +27,7 @@ permission:
   question: allow
   todowrite: allow
   webfetch: allow
+  "*": deny
 ---
 
 ## Role

--- a/.opencode/agents/review.md
+++ b/.opencode/agents/review.md
@@ -21,6 +21,7 @@ permission:
   question: allow
   websearch: deny
   webfetch: deny
+  "*": deny
 ---
 
 ## Role

--- a/.opencode/agents/think.md
+++ b/.opencode/agents/think.md
@@ -13,6 +13,7 @@ permission:
   todowrite: allow
   websearch: allow
   webfetch: allow
+  "*": deny
 ---
 
 ## Role


### PR DESCRIPTION
## What

Hardens the permission blocks of all three opencode agents (`build`, `review`, `think`) by:

1. Adding `"*": deny` as the final catch-all entry in every top-level permission block, so any tool not explicitly listed is denied rather than implicitly allowed.
2. Adding `"git add *": allow` to `build`'s bash sub-block alongside the existing `"git add": allow`, ensuring `git add <files>` and `git add .` are covered (not just bare `git add`).

Follows the **last-match-wins** semantics documented in [opencode#7033](https://github.com/anomalyco/opencode/pull/7033) — the catch-all `"*": deny` is placed last so all specific `allow` rules above it take precedence.

## How to test

Review the updated frontmatter in each agent file and confirm:
- `.opencode/agents/build.md`: `"git add *": allow` present; `"*": deny` is the last line in both the `bash:` sub-block and the top-level `permission:` block.
- `.opencode/agents/review.md`: `"*": deny` is the last line in the top-level `permission:` block; bash sub-block order unchanged.
- `.opencode/agents/think.md`: `"*": deny` is the last line in the top-level `permission:` block.

## Impact

Agents no longer have implicitly open permissions for unlisted tools. Any new tool added to opencode will default to denied until explicitly allowed — reducing the blast radius of unexpected tool access.