### PR TITLE
feat(opencode): prevent bot self-trigger on PR comments

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -8,9 +8,14 @@ on:
 jobs:
   opencode:
     if: |
-      (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') 
-      && (contains(github.event.comment.body, '/opencode') || contains(github.event.comment.body, '/oc'))
-      || github.event_name == 'workflow_dispatch'
+      !endsWith(github.actor, '[bot]') &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') && 
+          (contains(github.event.comment.body, '/opencode') || contains(github.event.comment.body, '/oc'))
+        )
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## What

Added `!endsWith(github.actor, '[bot]')` guard to the opencode workflow's `if:` condition.

## How to test

1. Have a bot (e.g., opencode) post a PR comment with `/opencode build` — the workflow should **not** trigger.
2. Manually trigger `workflow_dispatch` — it should still work.
3. A human posts `/opencode build` on an issue/PR — the workflow should trigger normally.

## Impact

Prevents the opencode GitHub Action from being triggered by its own comments, eliminating circular self-triggering on PRs.