### PR TITLE
(chore)opencode: remove custom agent references

### DIFF
--- a/.github/opencode.json
+++ b/.github/opencode.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "default_agent": "think",
   "permission": {
     "skill": {
       "*": "allow"

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -29,21 +29,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Extract agent from comment
-        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment'
-        id: extract
-        env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
-        run: |
-          body=$(echo "$COMMENT_BODY" | tr '\n\r' ' ')
-          echo "$body" | grep -qE '(^|[[:space:]])\s*/opencode\s+build\b|^/opencode\s+build\b' && { echo "agent=build" >> $GITHUB_OUTPUT; exit 0; }
-          echo "$body" | grep -qE '(^|[[:space:]])\s*/oc\s+build\b|^/oc\s+build\b' && { echo "agent=build" >> $GITHUB_OUTPUT; exit 0; }
-          echo "$body" | grep -qE '(^|[[:space:]])\s*/opencode\s+review\b|^/opencode\s+review\b' && { echo "agent=review" >> $GITHUB_OUTPUT; exit 0; }
-          echo "$body" | grep -qE '(^|[[:space:]])\s*/oc\s+review\b|^/oc\s+review\b' && { echo "agent=review" >> $GITHUB_OUTPUT; exit 0; }
-          echo "$body" | grep -qE '(^|[[:space:]])\s*/opencode\s+think\b|^/opencode\s+think\b' && { echo "agent=think" >> $GITHUB_OUTPUT; exit 0; }
-          echo "$body" | grep -qE '(^|[[:space:]])\s*/oc\s+think\b|^/oc\s+think\b' && { echo "agent=think" >> $GITHUB_OUTPUT; exit 0; }
-          echo "agent=build" >> $GITHUB_OUTPUT
-
       - name: Run OpenCode
         uses: anomalyco/opencode/github@latest
         env:
@@ -51,4 +36,3 @@ jobs:
           OPENCODE_CONFIG: .github/opencode.json
         with:
           model: "litellm/unsloth/qwen-3.6"
-          agent: ${{ steps.extract.outputs.agent || 'build' }}


### PR DESCRIPTION
## What

- Removed custom agent references (build, review, think) from OpenCode config and GitHub workflow since custom agents are no longer in use.
- Deleted the Extract agent from comment step that parsed /opencode build|review|think subcommands.
- Removed default_agent: think from .github/opencode.json.
- Simplified workflow to run OpenCode without any agent mode — uses upstream default.

## How to Test

1. Check that .github/opencode.json no longer has a default_agent field.
2. Verify .github/workflows/opencode.yml runs without errors when triggered by /opencode or /oc comments.

## Impact

- Workflow simplification — no behavioral changes expected since upstream default behavior is the same as what build mode did.