### PR TITLE
fix(opencode): fix issue comment trigger

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -10,10 +10,9 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (
-        (github.event_name == 'issue_comment' && contains(fromJson('["OWNER","MEMBER"]'), github.event.issue.author_association)) ||
-        (github.event_name == 'pull_request_review_comment' && contains(fromJson('["OWNER","MEMBER"]'), github.event.pull_request.author_association))
-      ) &&
-      (contains(github.event.comment.body, '/opencode') || contains(github.event.comment.body, '/oc'))
+        contains(fromJson('["OWNER","MEMBER"]'), (github.event.issue.author_association || github.event.pull_request.author_association)) &&
+        (contains(github.event.comment.body, '/opencode') || contains(github.event.comment.body, '/oc'))
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -9,8 +9,10 @@ jobs:
   opencode:
     if: |
       github.event_name == 'workflow_dispatch' ||
-      contains(fromJson('["OWNER","MEMBER"]'), github.event.pull_request.author_association) &&
-      (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') && 
+      (
+        (github.event_name == 'issue_comment' && contains(fromJson('["OWNER","MEMBER"]'), github.event.issue.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(fromJson('["OWNER","MEMBER"]'), github.event.pull_request.author_association))
+      ) &&
       (contains(github.event.comment.body, '/opencode') || contains(github.event.comment.body, '/oc'))
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## What

Fixed the GitHub Actions workflow trigger condition that was failing for issue comments. The previous condition unconditionally accessed `github.event.pull_request.author_association`, which is null when comments are on issues (not pull requests). This caused `/oc` and `/opencode` commands on issues to never trigger the pipeline.

## How to Test

1. Merge this PR
2. Leave a comment on any issue with `/oc` or `/opencode`
3. Verify the workflow runs in the Actions tab

## Impact

- Issue comments with `/oc` or `/opencode` will now correctly trigger the workflow when authored by OWNER or MEMBER
- Pull request review comments continue to work as before