### PR TITLE
fix(opencode): check commenter author_association, not issue author

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -19,6 +19,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -30,7 +30,6 @@ jobs:
         uses: anomalyco/opencode/github@latest
         env:
           LITELLM_KEY: ${{ secrets.LITELLM_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENCODE_CONFIG: .github/opencode.json
           OPENCODE_PERMISSION: |
             {

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      id-token: write
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -30,6 +30,7 @@ jobs:
         uses: anomalyco/opencode/github@latest
         env:
           LITELLM_KEY: ${{ secrets.LITELLM_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENCODE_CONFIG: .github/opencode.json
           OPENCODE_PERMISSION: |
             {

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -10,7 +10,7 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (
-        contains(fromJson('["OWNER","MEMBER"]'), (github.event.issue.author_association || github.event.pull_request.author_association)) &&
+        contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association) &&
         (contains(github.event.comment.body, '/opencode') || contains(github.event.comment.body, '/oc'))
       )
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

The previous fix still failed because `github.event.issue.author_association` is the association of the **issue/PR author**, not the person leaving the comment. When a bot creates a PR (e.g. opencode-agent) and you comment `/oc`, the issue author_association is `NONE` (bot), causing the check to fail.

The correct field is `github.event.comment.author_association` — this is the association of the **commenter** and works identically for both `issue_comment` and `pull_request_review_comment` events.

## How to Test

1. Merge this PR
2. Comment `/oc` on any issue or PR (including bot-created ones)
3. Verify the workflow runs

## Impact

- No more false negatives when commenting on bot-created PRs
- Simpler condition — one unified field for both event types