### PR TITLE
(fix)opencode: honour project-root AGENTS.md

### DIFF
--- a/.github/opencode.json
+++ b/.github/opencode.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "instructions": ["../AGENTS.md"],
   "compaction": {
     "auto": true,
     "prune": true,


### PR DESCRIPTION
## What

- Added `instructions: ["../AGENTS.md"]` to `.github/opencode.json` so the OpenCode GitHub Action agent always loads the project-root `AGENTS.md` regardless of where `opencode.json` lives.

## How to Test

1. Trigger the OpenCode GitHub Action with `/oc` on any issue or PR.
2. Verify that the agent follows the conventions defined in `AGENTS.md` (e.g., Kustomize base/overlays pattern, security contexts, ConfigMap usage, etc.).
3. Confirm the agent no longer ignores project-specific rules when invoked via GitHub Actions.

## Impact

- Low risk — additive change only; the agent will now consistently apply project-specific rules when invoked via GitHub Actions.