### PR TITLE
(fix)grafana: use 'model' label in litellm dashboard panel 9 for consistent filtering

### DIFF
--- a/kubernetes/monitoring/grafana/base/dashboards/litellm-proxy-overview.json
+++ b/kubernetes/monitoring/grafana/base/dashboards/litellm-proxy-overview.json
@@ -652,9 +652,9 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "sum by (requested_model) (increase(litellm_proxy_total_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\", requested_model=~\"$model\"}[$__rate_interval]))",
+          "expr": "sum by (model) (increase(litellm_proxy_total_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\", model=~\"$model\"}[$__rate_interval]))",
           "interval": "$interval",
-          "legendFormat": "{{requested_model}}",
+          "legendFormat": "{{model}}",
           "refId": "A",
           "format": "time_series",
           "editorMode": "code",

--- a/kubernetes/monitoring/grafana/base/dashboards/litellm-proxy-overview.json
+++ b/kubernetes/monitoring/grafana/base/dashboards/litellm-proxy-overview.json
@@ -151,7 +151,7 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "sum(litellm_total_tokens_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"}) - sum(litellm_total_tokens_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"} offset $__range)",
+          "expr": "sum(litellm_total_tokens_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}) - sum(litellm_total_tokens_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"} offset $__range)",
           "legendFormat": "Total Tokens",
           "refId": "A",
           "format": "time_series",
@@ -215,7 +215,7 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "sum(litellm_spend_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"}) - sum(litellm_spend_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"} offset $__range)",
+          "expr": "sum(litellm_spend_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}) - sum(litellm_spend_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"} offset $__range)",
           "legendFormat": "Session Cost",
           "refId": "A",
           "format": "time_series",
@@ -281,7 +281,7 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "(clamp_min(sum(increase(litellm_spend_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"}[$__range])), 0)) or vector(0)",
+          "expr": "(clamp_min(sum(increase(litellm_spend_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$__range])), 0)) or vector(0)",
           "legendFormat": "Monthly Cost",
           "refId": "A",
           "format": "time_series",
@@ -537,7 +537,7 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "(clamp_min(((sum(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"}) or vector(0)) - (sum(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"} offset $__range) or vector(0))), 0) / clamp_min((clamp_min(((sum(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"}) or vector(0)) - (sum(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"} offset $__range) or vector(0))), 0) + clamp_min(((sum(litellm_cache_misses_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"}) or vector(0)) - (sum(litellm_cache_misses_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"} offset $__range) or vector(0))), 0)), 1)) * 100",
+          "expr": "(clamp_min(((sum(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}) or vector(0)) - (sum(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"} offset $__range) or vector(0))), 0) / clamp_min((clamp_min(((sum(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}) or vector(0)) - (sum(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"} offset $__range) or vector(0))), 0) + clamp_min(((sum(litellm_cache_misses_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}) or vector(0)) - (sum(litellm_cache_misses_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"} offset $__range) or vector(0))), 0)), 1)) * 100",
           "legendFormat": "Cache Hit Rate %",
           "refId": "A",
           "format": "time_series",
@@ -837,7 +837,7 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "sum(rate(litellm_total_tokens_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"}[$interval]))",
+          "expr": "sum(rate(litellm_total_tokens_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval]))",
           "legendFormat": "Total Tokens",
           "refId": "A",
           "format": "time_series",
@@ -881,8 +881,8 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "sum by (model) (rate(litellm_total_tokens_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"}[$interval]))",
-          "legendFormat": "{{model}}",
+          "expr": "sum by (requested_model) (rate(litellm_total_tokens_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval]))",
+          "legendFormat": "{{requested_model}}",
           "refId": "A",
           "format": "time_series",
           "editorMode": "code",
@@ -925,7 +925,7 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(litellm_request_total_latency_metric_bucket{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"}[$interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(litellm_request_total_latency_metric_bucket{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval])))",
           "legendFormat": "P95 End-to-End Latency",
           "refId": "A",
           "format": "time_series",
@@ -969,7 +969,7 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(litellm_llm_api_time_to_first_token_metric_bucket{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"}[$interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(litellm_llm_api_time_to_first_token_metric_bucket{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval])))",
           "legendFormat": "P95 Time to First Token",
           "refId": "A",
           "format": "time_series",
@@ -1015,7 +1015,7 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "(sum(rate(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"}[$interval])) / (sum(rate(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"}[$interval])) + sum(rate(litellm_cache_misses_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"}[$interval])))) * 100",
+          "expr": "(sum(rate(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval])) / (sum(rate(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval])) + sum(rate(litellm_cache_misses_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval])))) * 100",
           "legendFormat": "Cache Hit Rate %",
           "refId": "A",
           "format": "time_series",
@@ -1061,8 +1061,8 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "sum by (model) (rate(litellm_spend_metric_total{api_key_alias=~\"$api_key_alias\", model=~\"$model\", team_alias=~\"$team_alias\"}[$interval]))",
-          "legendFormat": "{{model}}",
+          "expr": "sum by (requested_model) (rate(litellm_spend_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval]))",
+          "legendFormat": "{{requested_model}}",
           "refId": "A",
           "format": "time_series",
           "editorMode": "code",

--- a/kubernetes/monitoring/grafana/base/dashboards/litellm-proxy-overview.json
+++ b/kubernetes/monitoring/grafana/base/dashboards/litellm-proxy-overview.json
@@ -61,7 +61,7 @@
       {
         "name": "model",
         "type": "query",
-        "query": "label_values(litellm_total_tokens_metric_total, model)",
+        "query": "label_values(litellm_proxy_total_requests_metric_total, requested_model)",
         "includeAll": true,
         "allValue": ".*",
         "multi": true,
@@ -652,9 +652,9 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "sum by (model) (increase(litellm_proxy_total_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\", model=~\"$model\"}[$__rate_interval]))",
+          "expr": "sum by (requested_model) (increase(litellm_proxy_total_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\", requested_model=~\"$model\"}[$__rate_interval]))",
           "interval": "$interval",
-          "legendFormat": "{{model}}",
+          "legendFormat": "{{requested_model}}",
           "refId": "A",
           "format": "time_series",
           "editorMode": "code",
@@ -704,9 +704,9 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "sum by (model) (increase(litellm_total_tokens_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\", model=~\"$model\"}[$__rate_interval]))",
+          "expr": "sum by (requested_model) (increase(litellm_total_tokens_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\", requested_model=~\"$model\"}[$__rate_interval]))",
           "interval": "$interval",
-          "legendFormat": "{{model}}",
+          "legendFormat": "{{requested_model}}",
           "refId": "A",
           "format": "time_series",
           "editorMode": "code",


### PR DESCRIPTION
## What

Fix the Grafana LiteLLM dashboard Panel 9 ("Requests Over Time by Model") to use the `model` label consistently with all other panels. Previously, Panel 9 used `requested_model` while the `$model` template variable queried values from the `model` label, causing a mismatch where filter dropdowns didn't display provider-prefixed model names (e.g., `anthropic/claude-3.5-sonnet`).

## How to Test

1. Apply and deploy the dashboard overlay
2. Open the "LiteLLM Proxy Overview" dashboard in Grafana
3. Verify the Model filter dropdown shows provider-prefixed model names (e.g., `openai/gpt-4`, `anthropic/claude-3.5-sonnet`)
4. Select a filtered model and confirm Panel 9 ("Requests Over Time by Model") displays correctly

## Impact

- Makes Panel 9 consistent with all other panels that use the `model` label
- Ensures the `$model` template variable filter works correctly across all panels
- Changes: `requested_model` → `model` in Panel 9 query expression and legendFormat