### PR TITLE
(fix)metrics-server: increase metric-resolution from 15s to 30s

### DIFF
--- a/kubernetes/infra/metrics-server/overlays/default/values.yaml
+++ b/kubernetes/infra/metrics-server/overlays/default/values.yaml
@@ -1,6 +1,6 @@
 args:
   - --kubelet-insecure-tls
   - --kubelet-preferred-address-types=InternalIP
-  - --metric-resolution=15s
+  - --metric-resolution=30s
 extraArgs:
   - --kubelet-use-node-status-port

--- a/kubernetes/monitoring/grafana/base/dashboards/litellm-proxy-overview.json
+++ b/kubernetes/monitoring/grafana/base/dashboards/litellm-proxy-overview.json
@@ -22,12 +22,17 @@
         "name": "interval",
         "type": "custom",
         "label": "Interval",
-        "query": "1m,5m,15m,1h,6h",
+        "query": "30s,1m,5m,15m,1h,6h",
         "current": {
           "text": "5m",
           "value": "5m"
         },
         "options": [
+          {
+            "text": "30s",
+            "value": "30s",
+            "selected": false
+          },
           {
             "text": "1m",
             "value": "1m",


### PR DESCRIPTION
This PR is being closed — it mixed two unrelated changes (metrics-server resolution + grafana interval). See the new dedicated PRs for each.