### PR TITLE
(fix)grafana: add 30s interval option to litellm dashboard

### DIFF
--- a/kubernetes/monitoring/grafana/base/dashboards/litellm-proxy-overview.json
+++ b/kubernetes/monitoring/grafana/base/dashboards/litellm-proxy-overview.json
@@ -22,12 +22,17 @@
         "name": "interval",
         "type": "custom",
         "label": "Interval",
-        "query": "1m,5m,15m,1h,6h",
+        "query": "30s,1m,5m,15m,1h,6h",
         "current": {
           "text": "5m",
           "value": "5m"
         },
         "options": [
+          {
+            "text": "30s",
+            "value": "30s",
+            "selected": false
+          },
           {
             "text": "1m",
             "value": "1m",


### PR DESCRIPTION
## What

Add a 30s option to the litellm dashboard's Interval dropdown variable. Previously the minimum available interval was 1 minute, making it impossible to inspect short-duration traffic patterns like individual API call bursts.

## How to Test

1. Deploy the overlay and open the "LiteLLM Proxy Overview" dashboard
2. Click the Interval selector — "30s" should appear as the first option
3. Select "30s" and verify panels using `$interval` (e.g., Request Success Rate, Token Throughput, Request Latency P95) display correctly with 30-second granularity

## Impact

- 7 panels benefit from the new 30s interval: Request Success Rate, Token Throughput Over Time, Token Throughput per Model, Request Latency P95, Time to First Token P95, Cache Hit Rate Over Time, Cost Rate by Model
- No changes to metrics-server polling (still 15s) — only the Grafana dashboard query variable is affected