### PR TITLE
(fix)opencode: add missing metadata.name to endpointslice.yaml

### DIFF
--- a/kubernetes/apps/opencode/base/endpointslice.yaml
+++ b/kubernetes/apps/opencode/base/endpointslice.yaml
@@ -1,6 +1,7 @@
 apiVersion: discovery.k8s.io/v1
 kind: EndpointSlice
 metadata:
+  name: opencode-nixos
   annotations:
     kubernetes.io/service-name: opencode
   labels:


### PR DESCRIPTION
## What

Added the missing `metadata.name` field to the EndpointSlice resource in the opencode base kustomize manifest.

## How to Test

- Pull this branch and run `kustomize build kubernetes/apps/opencode/overlays/default/` — it should succeed without errors.
- Verify Fluxcd reconciles the apps-production Kustomization successfully (no more `kustomize build failed` error).

## Impact

- Fixes the kustomize-controller reconciliation failure for `apps-production`: `missing metadata.name in object {discovery.k8s.io/v1 EndpointSlice}`
- No functional changes to deployed resources; only adds a required Kubernetes metadata field.