### PR TITLE
(fix)litellm: remove conflicting bootstrap.initdb from base db.yaml

### DIFF
--- a/kubernetes/apps/litellm/base/db.yaml
+++ b/kubernetes/apps/litellm/base/db.yaml
@@ -10,10 +10,6 @@ spec:
     size: 3Gi
   monitoring:
     enablePodMonitor: true
-  bootstrap:
-    initdb:
-      database: litellm
-      owner: litellm
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true


### PR DESCRIPTION
## What

Remove incorrectly added `bootstrap.initdb` from `kubernetes/apps/litellm/base/db.yaml`.

Commit 668c00a (session #153) added back `bootstrap.initdb` to the base manifest after a migration (commit 7909ccf) that switched all DB apps from initdb to recovery bootstrap via overlay patches. This created a conflict where CNPG's admission webhook detected both `initdb` and `recovery` bootstrap methods being specified, causing FluxCD reconciliation to fail with:

> "Only one bootstrap method can be specified at a time"

The base should have no `bootstrap` section — the overlay's `$patch: replace` correctly replaces it with `recovery`. This now matches the pattern used by all other database apps (paperless-ngx, n8n, coder, etc.).

## How to Test

1. Run `kustomize build kubernetes/apps/overlays/production` and verify no errors
2. Check that `litellm-db` Cluster resource shows only `bootstrap.recovery` (no `initdb`)
3. Verify FluxCD reconciles successfully after merge

## Impact

- Fixes CNPG webhook validation error blocking `apps-production` FluxCD Kustomization
- Restores consistency with all other database app configurations