### PR TITLE
fix(db): replace $patch: replace with initdb: null to fix dual bootstrap error

### DIFF
--- a/kubernetes/apps/coder/overlays/default/db.yaml
+++ b/kubernetes/apps/coder/overlays/default/db.yaml
@@ -4,6 +4,6 @@ metadata:
   name: coder-db
 spec:
   bootstrap:
-    $patch: replace
+    initdb: null
     recovery:
       source: clusterBackup

--- a/kubernetes/apps/commafeed/overlays/default/db.yaml
+++ b/kubernetes/apps/commafeed/overlays/default/db.yaml
@@ -4,6 +4,6 @@ metadata:
   name: commafeed-db
 spec:
   bootstrap:
-    $patch: replace
+    initdb: null
     recovery:
       source: clusterBackup

--- a/kubernetes/apps/immich/overlays/default/db.yaml
+++ b/kubernetes/apps/immich/overlays/default/db.yaml
@@ -4,6 +4,6 @@ metadata:
   name: immich-db
 spec:
   bootstrap:
-    $patch: replace
+    initdb: null
     recovery:
       source: clusterBackup

--- a/kubernetes/apps/life-in-the-uk-quiz/overlays/default/db.yaml
+++ b/kubernetes/apps/life-in-the-uk-quiz/overlays/default/db.yaml
@@ -4,6 +4,6 @@ metadata:
   name: life-in-the-uk-quiz-db
 spec:
   bootstrap:
-    $patch: replace
+    initdb: null
     recovery:
       source: clusterBackup

--- a/kubernetes/apps/litellm/overlays/default/db.yaml
+++ b/kubernetes/apps/litellm/overlays/default/db.yaml
@@ -4,6 +4,6 @@ metadata:
   name: litellm-db
 spec:
   bootstrap:
-    $patch: replace
+    initdb: null
     recovery:
       source: clusterBackup

--- a/kubernetes/apps/n8n/overlays/default/db.yaml
+++ b/kubernetes/apps/n8n/overlays/default/db.yaml
@@ -4,6 +4,6 @@ metadata:
   name: n8n-db
 spec:
   bootstrap:
-    $patch: replace
+    initdb: null
     recovery:
       source: clusterBackup

--- a/kubernetes/apps/paperless-ngx/overlays/default/db.yaml
+++ b/kubernetes/apps/paperless-ngx/overlays/default/db.yaml
@@ -4,6 +4,6 @@ metadata:
   name: paperless-db
 spec:
   bootstrap:
-    $patch: replace
+    initdb: null
     recovery:
       source: clusterBackup


### PR DESCRIPTION
## What

Fixes the "Only one bootstrap method can be specified at a time" error when applying CloudNativePG Cluster resources in production.

All 7 database overlays were using `$patch: replace` on `spec.bootstrap`, which caused Kustomize to deep-merge the overlay's `recovery` with the base's `initdb` — resulting in both bootstrap methods being present simultaneously. The CNPG admission webhook rejects this as invalid.

## How

Replace `$patch: replace` with `initdb: null` in each overlay's db.yaml patch. This explicitly deletes the `initdb` field from the base manifest during Kustomize's deep merge, leaving only `recovery` under `spec.bootstrap`.

Reference: [CNPG Bootstrap Documentation](https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-backup-recovery) states that exactly one bootstrap method must be specified at a time. Using `initdb: null` ensures the field is removed rather than merged.

## Impact

- **coder-db** (namespace: coder)
- **commafeed-db** (namespace: commafeed)
- **immich-db** (namespace: immich)
- **life-in-the-uk-quiz-db** (namespace: life-in-the-uk-quiz)
- **litellm-db** (namespace: llm)
- **n8n-db** (namespace: n8n)
- **paperless-db** (namespace: paperless)

After merge and Flux sync, all 7 database clusters will transition to recovery mode (restoring from backups) instead of attempting to create a new cluster with conflicting bootstrap methods.