### PR TITLE
(chore)renovate: add minimum 14-day release age

### DIFF
--- a/kubernetes/infra/renovate/overlays/default/config.json
+++ b/kubernetes/infra/renovate/overlays/default/config.json
@@ -13,6 +13,7 @@
   "pinDigests": true,
   "prHourlyLimit": 0,
   "prConcurrentLimit": 10,
+  "minimumReleaseAge": "14 days",
   "internalChecksFilter": "flexible",
   "packageRules": [
     {

--- a/kubernetes/infra/renovate/overlays/default/config.json
+++ b/kubernetes/infra/renovate/overlays/default/config.json
@@ -14,6 +14,7 @@
   "prHourlyLimit": 0,
   "prConcurrentLimit": 10,
   "minimumReleaseAge": "14 days",
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
   "internalChecksFilter": "flexible",
   "packageRules": [
     {


### PR DESCRIPTION
## What
Adds `"minimumReleaseAge": "14 days"` to the Renovate configuration file. This ensures that Renovate waits at least 14 days after a package release before considering it for updates, providing a buffer against buggy or incomplete first releases.

## How to Test
- Verify the config is valid JSON: `python3 -m json.tool kubernetes/infra/renovate/overlays/default/config.json`
- Check Renovate runs successfully and respects the 14-day minimum release age setting.

## Impact
- Renovate will now delay processing releases until they are at least 14 days old.
- This is a non-strict setting — it won't block updates if there haven't been enough releases or long-enough-lived releases yet.