### PR TITLE
(chore)renovate: detect Renovate PRs by branch name

### DIFF
--- a/.github/workflows/renovate-review.yml
+++ b/.github/workflows/renovate-review.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   review-renovate-pr:
-    if: ${{ github.event.pull_request.user.login == 'renovate[bot]' }}
+    if: ${{ startsWith(github.head_ref, 'renovate/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## What

Updated the `renovate-review` GitHub Actions workflow to identify Renovate pull requests by branch name prefix (`renovate/`) instead of checking if the PR author is `renovate[bot]`.

This fixes cases where Renovate opens PRs using a user's PAT (Personal Access Token), causing the PR to appear authored by the user (e.g., `leehosanganson`) rather than `renovate[bot]`. In those cases, the previous condition `github.event.pull_request.user.login == 'renovate[bot]'` evaluated to false and the review job was skipped.

## How to Test

1. Wait for Renovate to create a new PR (or trigger one manually)
2. Verify the `review-renovate-pr` action runs instead of being SKIPPED
3. Check the Action run log at https://github.com/leehosanganson/homelab/actions/runs/

## Impact

- All future Renovate PRs (regardless of whether authored by `renovate[bot]` or a PAT) will trigger the review action
- Non-Renovate PRs with `renovate/` prefix branches would also trigger it, but this is extremely unlikely in practice