### PR TITLE
(fix)opencode: fix renovate-review.yml PR comments

### DIFF
--- a/.github/opencode/opencode.json
+++ b/.github/opencode/opencode.json
@@ -22,8 +22,9 @@
         },
         "bash": {
           "*": "deny",
-          "gh issue comment*": "allow",
-          "gh pr comment*": "allow"
+          "gh issue comment *": "allow",
+          "gh pr comment *": "allow",
+          "gh api *": "allow"
         },
         "question": "deny",
         "edit": "deny",
@@ -52,12 +53,12 @@
         },
         "bash": {
           "*": "deny",
-          "git status*": "allow",
-          "git diff*": "allow",
-          "git log*": "allow",
-          "git rev-parse*": "allow",
-          "gh issue comment*": "allow",
-          "gh pr comment*": "allow"
+          "git status *": "allow",
+          "git diff *": "allow",
+          "git log *": "allow",
+          "git rev-parse *": "allow",
+          "gh issue comment *": "allow",
+          "gh pr comment *": "allow"
         },
         "question": "deny",
         "external_directory": "deny",
@@ -80,11 +81,11 @@
         "list": "allow",
         "bash": {
           "*": "deny",
-          "git status*": "allow",
-          "git diff*": "allow",
-          "git log*": "allow",
-          "gh issue comment*": "allow",
-          "gh pr comment*": "allow"
+          "git status *": "allow",
+          "git diff *": "allow",
+          "git log *": "allow",
+          "gh issue comment *": "allow",
+          "gh pr comment *": "allow"
         },
         "task": "deny",
         "question": "deny",

--- a/.github/workflows/renovate-review.yml
+++ b/.github/workflows/renovate-review.yml
@@ -28,6 +28,7 @@ jobs:
           echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} > pr_data.json
           echo "title=$(jq -r .title pr_data.json)" >> $GITHUB_OUTPUT
+          echo "sha=$(jq -r .head.sha pr_data.json)" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -43,6 +44,10 @@ jobs:
           <pr-number>
           ${{ github.event.pull_request.number }}
           </pr-number>
+
+          <commit-sha>
+          ${{ steps.pr-details.outputs.sha }}
+          </commit-sha>
 
           <pr-description>
           $PR_BODY
@@ -70,7 +75,26 @@ jobs:
           ## 6. NixOS-Specific Checks
           - When PR modifies \`flake.lock\` or NixOS host configs: compare old vs new git hash in flake.lock. Assess if any service versions being upgraded have known breaking changes (check nixpkgs commit messages). Flag upgrades that touch \`system.stateVersion\` or require \`nixos-rebuild\` migration steps. For multi-host setups (haproxy-1/2/3, opencode-1): note which hosts are affected and whether service restart patterns need coordination.
 
-          Provide a concise summary with:
+          Post a summary review comment on this PR thread using \`gh pr comment\`, replacing placeholders with actual values:
+          
+          ```bash
+          gh pr comment <PR_NUMBER> --body '<MULTILINE_COMMENT>'
+          ```
+
+          The summary should include:
           - **Status:** PASS / NEEDS_REVISION
-          - **Findings:** Bullet points for each category checked
-          - **Recommendation:** Clear go/no-go suggestion"
+          - **Findings:** Bullet points for each category checked (1-6)
+          - **Recommendation:** Clear go/no-go suggestion
+
+          When you find specific issues in files, leave inline file comments using \`gh api\`, replacing placeholders:
+          
+          ```bash
+          gh api \\
+            --method POST \\
+            -H "Accept: application/vnd.github+json" \\
+            -H "X-GitHub-Api-Version: 2022-11-28" \\
+            /repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/comments \\
+            -f 'body=[summary of issue]' -f 'commit_id=<COMMIT_SHA>' -f 'path=[path-to-file]' -F 'line=[line]' -f 'side=RIGHT'
+          ```
+
+          Replace <OWNER>/<REPO> with ${{ github.repository }}, <PR_NUMBER> with ${{ github.event.pull_request.number }}, and <COMMIT_SHA> with the HEAD commit SHA."

--- a/.github/workflows/renovate-review.yml
+++ b/.github/workflows/renovate-review.yml
@@ -28,7 +28,6 @@ jobs:
           echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} > pr_data.json
           echo "title=$(jq -r .title pr_data.json)" >> $GITHUB_OUTPUT
-          echo "sha=$(jq -r .head.sha pr_data.json)" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -46,7 +45,7 @@ jobs:
           </pr-number>
 
           <commit-sha>
-          ${{ steps.pr-details.outputs.sha }}
+          ${{ github.event.pull_request.head.sha }}
           </commit-sha>
 
           <pr-description>
@@ -97,4 +96,4 @@ jobs:
             -f 'body=[summary of issue]' -f 'commit_id=<COMMIT_SHA>' -f 'path=[path-to-file]' -F 'line=[line]' -f 'side=RIGHT'
           ```
 
-          Replace <OWNER>/<REPO> with ${{ github.repository }}, <PR_NUMBER> with ${{ github.event.pull_request.number }}, and <COMMIT_SHA> with the HEAD commit SHA."
+          Replace <OWNER>/<REPO> with ${{ github.repository }}, <PR_NUMBER> with ${{ github.event.pull_request.number }}, and <COMMIT_SHA> with \`${{ github.event.pull_request.head.sha }}\`."


### PR DESCRIPTION
## What

The `renovate-review.yml` GitHub Action was reviewing Renovate PRs but never posting its findings back to the PR thread. This was because:

- The prompt told OpenCode to "provide a concise summary" but never instructed it *where* or *how* to post that summary.
- The architect agent's bash permissions allowed `gh pr comment*` and `gh issue comment*` but not `gh api *`, so inline file comments couldn't be posted either.

Fixed by:
1. Updating the prompt to explicitly instruct OpenCode to post a summary PR comment using `gh pr comment`.
2. Adding `gh api *` permission to the architect agent's bash permissions for inline file comments.
3. Extracting the HEAD commit SHA so inline comments can target specific lines.

## How to Test

1. Push this branch and wait for the Renovate-review action to run (triggered by a PR with a `renovate/` branch name).
2. Check the PR thread — OpenCode should post a summary comment with Status, Findings, and Recommendation.
3. If issues are found in specific files, inline comments should appear on those files.

## Impact

- No user-facing changes; only affects the Renovate review GitHub Action behavior.
- The `opencode.json` config now grants `gh api *` to the architect agent — this is needed for inline file comments and is consistent with what the action already requires.