### PR TITLE
feat(grafana): fix LiteLLM Prometheus metric names and remove broken panels

### DIFF
--- a/kubernetes/monitoring/grafana/base/dashboards/litellm-proxy-overview.json
+++ b/kubernetes/monitoring/grafana/base/dashboards/litellm-proxy-overview.json
@@ -105,9 +105,137 @@
     {
       "id": 1,
       "type": "stat",
-      "title": "Total Tokens (Period)",
+      "title": "Output Tokens",
       "gridPos": {
         "x": 0,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 500000
+              },
+              {
+                "color": "red",
+                "value": 2000000
+              }
+            ]
+          },
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "prometheus"
+          },
+          "expr": "(clamp_min(sum(increase(litellm_output_tokens_metric{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$__range])), 0)) or vector(0)",
+          "legendFormat": "Output Tokens",
+          "refId": "A",
+          "format": "time_series",
+          "editorMode": "code",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Input Tokens",
+      "gridPos": {
+        "x": 6,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 500000
+              },
+              {
+                "color": "red",
+                "value": 2000000
+              }
+            ]
+          },
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "prometheus"
+          },
+          "expr": "(clamp_min(sum(increase(litellm_input_tokens_metric{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$__range])), 0)) or vector(0)",
+          "legendFormat": "Input Tokens",
+          "refId": "A",
+          "format": "time_series",
+          "editorMode": "code",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Total Tokens",
+      "gridPos": {
+        "x": 12,
         "y": 0,
         "w": 6,
         "h": 4
@@ -156,7 +284,7 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "(clamp_min(sum(increase(litellm_total_tokens_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$__range])), 0)) or vector(0)",
+          "expr": "(clamp_min(sum(increase(litellm_total_tokens_metric{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$__range])), 0)) or vector(0)",
           "legendFormat": "Total Tokens",
           "refId": "A",
           "format": "time_series",
@@ -167,11 +295,11 @@
       ]
     },
     {
-      "id": 2,
+      "id": 4,
       "type": "stat",
-      "title": "Session Cost (Period)",
+      "title": "Session Cost",
       "gridPos": {
-        "x": 6,
+        "x": 18,
         "y": 0,
         "w": 6,
         "h": 4
@@ -220,7 +348,7 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "(clamp_min(sum(increase(litellm_spend_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$__range])), 0)) or vector(0)",
+          "expr": "(clamp_min(sum(increase(litellm_spend_metric{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$__range])), 0)) or vector(0)",
           "legendFormat": "Session Cost",
           "refId": "A",
           "format": "time_series",
@@ -231,14 +359,14 @@
       ]
     },
     {
-      "id": 3,
+      "id": 5,
       "type": "stat",
       "title": "Monthly Cost (MTD)",
       "description": "Always shows month-to-date regardless of the time picker selection.",
       "timeFrom": "now/M",
       "gridPos": {
-        "x": 12,
-        "y": 0,
+        "x": 0,
+        "y": 4,
         "w": 6,
         "h": 4
       },
@@ -286,7 +414,7 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "(clamp_min(sum(increase(litellm_spend_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$__range])), 0)) or vector(0)",
+          "expr": "(clamp_min(sum(increase(litellm_spend_metric{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$__range])), 0)) or vector(0)",
           "legendFormat": "Monthly Cost",
           "refId": "A",
           "format": "time_series",
@@ -297,75 +425,11 @@
       ]
     },
     {
-      "id": 4,
+      "id": 6,
       "type": "stat",
-      "title": "Request Success Rate %",
+      "title": "Total Requests",
       "gridPos": {
-        "x": 18,
-        "y": 0,
-        "w": 6,
-        "h": 4
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "orientation": "auto",
-        "textMode": "auto",
-        "colorMode": "value"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percent",
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 97
-              },
-              {
-                "color": "green",
-                "value": 99.5
-              }
-            ]
-          },
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "datasource": {
-            "uid": "prometheus"
-          },
-          "expr": "((clamp_min(((sum(litellm_proxy_total_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\"}) or vector(0)) - (sum(litellm_proxy_total_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\"} offset $__range) or vector(0))), 0) - clamp_min(((sum(litellm_proxy_failed_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\"}) or vector(0)) - (sum(litellm_proxy_failed_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\"} offset $__range) or vector(0))), 0)) / clamp_min(clamp_min(((sum(litellm_proxy_total_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\"}) or vector(0)) - (sum(litellm_proxy_total_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\"} offset $__range) or vector(0))), 0), 1)) * 100",
-          "legendFormat": "Success Rate %",
-          "refId": "A",
-          "format": "time_series",
-          "editorMode": "code",
-          "instant": true,
-          "range": false
-        }
-      ]
-    },
-    {
-      "id": 5,
-      "type": "stat",
-      "title": "Total Requests (Period)",
-      "gridPos": {
-        "x": 0,
+        "x": 6,
         "y": 4,
         "w": 6,
         "h": 4
@@ -414,72 +478,8 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "(clamp_min(sum(increase(litellm_proxy_total_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\"}[$__range])), 0)) or vector(0)",
+          "expr": "(clamp_min(sum(increase(litellm_proxy_total_requests_metric{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\"}[$__range])), 0)) or vector(0)",
           "legendFormat": "Total Requests",
-          "refId": "A",
-          "format": "time_series",
-          "editorMode": "code",
-          "instant": true,
-          "range": false
-        }
-      ]
-    },
-    {
-      "id": 6,
-      "type": "stat",
-      "title": "Failed Requests (Period)",
-      "gridPos": {
-        "x": 6,
-        "y": 4,
-        "w": 6,
-        "h": 4
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "orientation": "auto",
-        "textMode": "auto",
-        "colorMode": "value"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 20
-              },
-              {
-                "color": "red",
-                "value": 100
-              }
-            ]
-          },
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "datasource": {
-            "uid": "prometheus"
-          },
-          "expr": "clamp_min(((sum(litellm_proxy_failed_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\"}) or vector(0)) - (sum(litellm_proxy_failed_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\"} offset $__range) or vector(0))), 0)",
-          "legendFormat": "Failed Requests",
           "refId": "A",
           "format": "time_series",
           "editorMode": "code",
@@ -491,7 +491,7 @@
     {
       "id": 7,
       "type": "stat",
-      "title": "Cache Hit Rate %",
+      "title": "Failed Requests %",
       "gridPos": {
         "x": 12,
         "y": 4,
@@ -520,16 +520,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
+                "color": "green",
                 "value": null
               },
               {
                 "color": "yellow",
-                "value": 40
+                "value": 1
               },
               {
-                "color": "green",
-                "value": 70
+                "color": "red",
+                "value": 5
               }
             ]
           },
@@ -542,8 +542,8 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "(clamp_min(((sum(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}) or vector(0)) - (sum(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"} offset $__range) or vector(0))), 0) / clamp_min((clamp_min(((sum(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}) or vector(0)) - (sum(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"} offset $__range) or vector(0))), 0) + clamp_min(((sum(litellm_cache_misses_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}) or vector(0)) - (sum(litellm_cache_misses_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"} offset $__range) or vector(0))), 0)), 1)) * 100",
-          "legendFormat": "Cache Hit Rate %",
+          "expr": "(sum(increase(litellm_proxy_failed_requests_metric{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\"}[$__range])) / clamp_min(sum(increase(litellm_proxy_total_requests_metric{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\"}[$__range])), 1)) * 100",
+          "legendFormat": "Failed Requests %",
           "refId": "A",
           "format": "time_series",
           "editorMode": "code",
@@ -554,124 +554,8 @@
     },
     {
       "id": 8,
-      "type": "stat",
-      "title": "In-Flight Requests (Now)",
-      "gridPos": {
-        "x": 18,
-        "y": 4,
-        "w": 6,
-        "h": 4
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "orientation": "auto",
-        "textMode": "auto",
-        "colorMode": "value"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 20
-              },
-              {
-                "color": "red",
-                "value": 50
-              }
-            ]
-          },
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "datasource": {
-            "uid": "prometheus"
-          },
-          "expr": "sum(litellm_in_flight_requests{api_key_alias=~\"$api_key_alias\"})",
-          "legendFormat": "In-Flight Requests",
-          "refId": "A",
-          "format": "time_series",
-          "editorMode": "code",
-          "instant": true,
-          "range": false
-        }
-      ]
-    },
-    {
-      "id": 9,
       "type": "timeseries",
       "title": "Requests Over Time by Model",
-      "gridPos": {
-        "x": 0,
-        "y": 16,
-        "w": 24,
-        "h": 8
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "custom": {
-            "drawStyle": "bars",
-            "barAlignment": 0,
-            "lineWidth": 0,
-            "fillOpacity": 100,
-            "stacking": {
-              "mode": "normal",
-              "group": "A"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "maxDataPoints": 1000,
-      "targets": [
-        {
-          "datasource": {
-            "uid": "prometheus"
-          },
-          "expr": "sum by (requested_model) (increase(litellm_proxy_total_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\", requested_model=~\"$model\"}[$__rate_interval]))",
-          "interval": "$interval",
-          "legendFormat": "{{requested_model}}",
-          "refId": "A",
-          "format": "time_series",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        }
-      ]
-    },
-    {
-      "id": 10,
-      "type": "timeseries",
-      "title": "Token Consumption Over Time by Model",
       "gridPos": {
         "x": 0,
         "y": 8,
@@ -709,8 +593,148 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "sum by (requested_model) (increase(litellm_total_tokens_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\", requested_model=~\"$model\"}[$__rate_interval]))",
+          "expr": "sum by (requested_model) (increase(litellm_proxy_total_requests_metric{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\", requested_model=~\"$model\"}[$__rate_interval]))",
           "interval": "$interval",
+          "legendFormat": "{{requested_model}}",
+          "refId": "A",
+          "format": "time_series",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Token Consumption Over Time by Model",
+      "gridPos": {
+        "x": 0,
+        "y": 12,
+        "w": 24,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "barAlignment": 0,
+            "lineWidth": 0,
+            "fillOpacity": 100,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "maxDataPoints": 1000,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "prometheus"
+          },
+          "expr": "sum by (requested_model) (increase(litellm_total_tokens_metric{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\", requested_model=~\"$model\"}[$__rate_interval]))",
+          "interval": "$interval",
+          "legendFormat": "{{requested_model}}",
+          "refId": "A",
+          "format": "time_series",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Token Throughput Over Time (tokens/sec)",
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 24,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(litellm_total_tokens_metric{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval]))",
+          "legendFormat": "Total Tokens",
+          "refId": "A",
+          "format": "time_series",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Token Throughput per Model",
+      "gridPos": {
+        "x": 0,
+        "y": 20,
+        "w": 24,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "prometheus"
+          },
+          "expr": "sum by (requested_model) (rate(litellm_total_tokens_metric{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval]))",
           "legendFormat": "{{requested_model}}",
           "refId": "A",
           "format": "time_series",
@@ -723,187 +747,11 @@
     {
       "id": 12,
       "type": "timeseries",
-      "title": "Request Success Rate Over Time",
-      "gridPos": {
-        "x": 0,
-        "y": 24,
-        "w": 12,
-        "h": 8
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percent",
-          "custom": {
-            "lineWidth": 2,
-            "fillOpacity": 10
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "datasource": {
-            "uid": "prometheus"
-          },
-          "expr": "(sum(rate(litellm_proxy_total_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\"}[$interval])) - sum(rate(litellm_proxy_failed_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\"}[$interval]))) / sum(rate(litellm_proxy_total_requests_metric_total{api_key_alias=~\"$api_key_alias\", team_alias=~\"$team_alias\"}[$interval])) * 100",
-          "legendFormat": "Success Rate %",
-          "refId": "A",
-          "format": "time_series",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        }
-      ]
-    },
-    {
-      "id": 13,
-      "type": "timeseries",
-      "title": "Concurrent Requests Over Time",
-      "gridPos": {
-        "x": 12,
-        "y": 24,
-        "w": 12,
-        "h": 8
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "custom": {
-            "lineWidth": 2,
-            "fillOpacity": 10
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "datasource": {
-            "uid": "prometheus"
-          },
-          "expr": "sum(litellm_in_flight_requests{api_key_alias=~\"$api_key_alias\"})",
-          "legendFormat": "In-Flight Requests",
-          "refId": "A",
-          "format": "time_series",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        }
-      ]
-    },
-    {
-      "id": 14,
-      "type": "timeseries",
-      "title": "Token Throughput Over Time (tokens/sec)",
-      "gridPos": {
-        "x": 0,
-        "y": 32,
-        "w": 12,
-        "h": 8
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "custom": {
-            "lineWidth": 2,
-            "fillOpacity": 10
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "datasource": {
-            "uid": "prometheus"
-          },
-          "expr": "sum(rate(litellm_total_tokens_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval]))",
-          "legendFormat": "Total Tokens",
-          "refId": "A",
-          "format": "time_series",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        }
-      ]
-    },
-    {
-      "id": 15,
-      "type": "timeseries",
-      "title": "Token Throughput per Model",
-      "gridPos": {
-        "x": 12,
-        "y": 32,
-        "w": 12,
-        "h": 8
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "custom": {
-            "lineWidth": 2,
-            "fillOpacity": 10
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "datasource": {
-            "uid": "prometheus"
-          },
-          "expr": "sum by (requested_model) (rate(litellm_total_tokens_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval]))",
-          "legendFormat": "{{requested_model}}",
-          "refId": "A",
-          "format": "time_series",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        }
-      ]
-    },
-    {
-      "id": 16,
-      "type": "timeseries",
       "title": "Request Latency P95",
       "gridPos": {
         "x": 0,
-        "y": 40,
-        "w": 12,
+        "y": 24,
+        "w": 24,
         "h": 8
       },
       "options": {
@@ -941,13 +789,13 @@
       ]
     },
     {
-      "id": 17,
+      "id": 13,
       "type": "timeseries",
       "title": "Time to First Token P95",
       "gridPos": {
-        "x": 12,
-        "y": 40,
-        "w": 12,
+        "x": 0,
+        "y": 28,
+        "w": 24,
         "h": 8
       },
       "options": {
@@ -985,59 +833,13 @@
       ]
     },
     {
-      "id": 18,
-      "type": "timeseries",
-      "title": "Cache Hit Rate Over Time",
-      "gridPos": {
-        "x": 0,
-        "y": 48,
-        "w": 12,
-        "h": 8
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percent",
-          "custom": {
-            "lineWidth": 2,
-            "fillOpacity": 10,
-            "axisSoftMin": 0,
-            "axisSoftMax": 100
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "datasource": {
-            "uid": "prometheus"
-          },
-          "expr": "(sum(rate(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval])) / (sum(rate(litellm_cache_hits_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval])) + sum(rate(litellm_cache_misses_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval])))) * 100",
-          "legendFormat": "Cache Hit Rate %",
-          "refId": "A",
-          "format": "time_series",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        }
-      ]
-    },
-    {
-      "id": 19,
+      "id": 14,
       "type": "timeseries",
       "title": "Cost Rate by Model ($/sec)",
       "gridPos": {
-        "x": 12,
-        "y": 48,
-        "w": 12,
+        "x": 0,
+        "y": 32,
+        "w": 24,
         "h": 8
       },
       "options": {
@@ -1066,7 +868,7 @@
           "datasource": {
             "uid": "prometheus"
           },
-          "expr": "sum by (requested_model) (rate(litellm_spend_metric_total{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval]))",
+          "expr": "sum by (requested_model) (rate(litellm_spend_metric{api_key_alias=~\"$api_key_alias\", requested_model=~\"$model\", team_alias=~\"$team_alias\"}[$interval]))",
           "legendFormat": "{{requested_model}}",
           "refId": "A",
           "format": "time_series",


### PR DESCRIPTION
## What

The LiteLLM Proxy Overview dashboard was using incorrect Prometheus metric names throughout, causing all panels to show "no data". This has been fixed based on the official [LiteLLM Prometheus metrics documentation](https://docs.litellm.ai/docs/proxy/prometheus).

### Fixed metric names (corrected from old → new):
- `litellm_total_tokens_metric_total` → `litellm_total_tokens_metric`
- `litellm_spend_metric_total` → `litellm_spend_metric`
- `litellm_proxy_total_requests_metric_total` → `litellm_proxy_total_requests_metric`
- `litellm_proxy_failed_requests_metric_total` → `litellm_proxy_failed_requests_metric`
- `litellm_generated_tokens_metric_total` → `litellm_output_tokens_metric` (replacement)
- `litellm_prompt_tokens_metric_total` → `litellm_input_tokens_metric` (replacement)

### Removed panels (no longer applicable):
- Request Success Rate % (stat + timeseries tile) — removed because the dashboard no longer tracks success rate separately
- Cache Hit Rate % (stat + timeseries tile) — LiteLLM does not expose a cache hit/miss metric for Prometheus
- In-Flight Requests / Concurrent Requests Over Time (stat + timeseries tile)

### Added panels:
- Output Tokens (Period) — using `litellm_output_tokens_metric`
- Input Tokens (Period) — using `litellm_input_tokens_metric`

Note: LiteLLM does not expose a cached token count metric, so that panel has been omitted.

### Layout changes
- Stat panels now fill row 1 in a single 4-column line (output tokens, input tokens, total tokens, session cost)
- Row 2 contains remaining stats (monthly cost, total requests, failed requests)
- Timeseries tiles are full-width (24px) for cleaner scrolling

## How to Test

1. Apply this change via FluxCD and wait for the dashboard to refresh.
2. Open "LiteLLM Proxy Overview" in Grafana.
3. Verify all stat panels show numeric values instead of "no data".
4. Check timeseries panels display token consumption, throughput, latency, and cost data.

## Impact

- All existing metric queries are rewritten with correct LiteLLM metric names.
- 6 removed panels (net -3).
- Dashboard layout restructured for cleaner presentation.