### PR TITLE
chore/renovate: use queue mode for concurrency in renovate-review workflow

### DIFF
--- a/.github/workflows/renovate-review.yml
+++ b/.github/workflows/renovate-review.yml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   review-renovate-pr:

--- a/.github/workflows/renovate-review.yml
+++ b/.github/workflows/renovate-review.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   review-renovate-pr:
     if: ${{ startsWith(github.head_ref, 'renovate/') }}


### PR DESCRIPTION
## What

Changed `cancel-in-progress` from `true` to `false` in the `renovate-review` workflow's concurrency configuration. This makes Renovate reviews run sequentially — new runs queue and wait for the current one to finish instead of being cancelled mid-execution.

**Before:**
```yaml
concurrency:
  group: ${{ github.workflow }}
  cancel-in-progress: true
```

**After:**
```yaml
concurrency:
  group: ${{ github.workflow }}
  cancel-in-progress: false
```

## How to Test

1. Push multiple Renovate PRs in quick succession (e.g., `git push --all`)
2. Check GitHub Actions — verify that runs queue and execute sequentially
3. The first run should complete before the next one starts

## Impact

- All Renovate review runs will now execute sequentially instead of cancelling each other
- Ensures no review is lost mid-execution when multiple PRs are triggered simultaneously
- Trade-off: reviews may take longer overall when many Renovate PRs are created at once, but each will complete fully