### PR TITLE
(feat)renovate: add git private key for SSH auth

### DIFF
--- a/kubernetes/infra/renovate/base/cronjob.yaml
+++ b/kubernetes/infra/renovate/base/cronjob.yaml
@@ -31,6 +31,11 @@ spec:
                   value: /usr/src/app/config.json
                 - name: LOG_LEVEL
                   value: "debug"
+                - name: RENOVATE_GIT_PRIVATE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: renovate-git-private-key
+                      key: GIT_PRIVATE_KEY
               volumeMounts:
                 - name: renovate-config
                   mountPath: /usr/src/app/config.json

--- a/kubernetes/infra/renovate/overlays/default/kustomization.yaml
+++ b/kubernetes/infra/renovate/overlays/default/kustomization.yaml
@@ -1,6 +1,7 @@
 namespace: renovate
 resources:
   - namespace.yaml
+  - secrets.yaml
   - ../../base
 
 configMapGenerator:

--- a/kubernetes/infra/renovate/overlays/default/secrets.yaml
+++ b/kubernetes/infra/renovate/overlays/default/secrets.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: renovate-git-private-key-external
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: azure-keyvault
+    kind: ClusterSecretStore
+  target:
+    name: renovate-git-private-key
+    creationPolicy: Owner
+  data:
+    - secretKey: GIT_PRIVATE_KEY
+      remoteRef:
+        key: renovate-git-private-key


### PR DESCRIPTION
## What

Adds `gitPrivateKey` configuration to the Renovate CronJob so it can authenticate via SSH against self-hosted repositories (e.g., GitLab, Gitea/Forgejo). This follows the [Renovate `gitPrivateKey`](https://docs.renovatebot.com/self-hosted-configuration/#gitprivatekey) self-hosted config option.

The SSH private key is fetched from Azure Key Vault via an ExternalSecret and passed to Renovate through the `RENOVATE_GIT_PRIVATE_KEY` environment variable.

## How to Test

1. Ensure the secret `renovate-git-private-key` exists in Azure Key Vault (create it with an Ed25519 or RSA SSH private key).
2. Apply the overlay (`kubernetes/infra/overlays/production/kustomization.yaml`) and verify Flux picks up the changes.
3. Check the CronJob pod logs for successful git clone/push operations against SSH-hosted repositories.

## Impact

- **New file**: `kubernetes/infra/renovate/overlays/default/secrets.yaml` — ExternalSecret manifest for the Git private key.
- **Existing files changed**: `base/cronjob.yaml` (added `RENOVATE_GIT_PRIVATE_KEY` env var), `overlays/default/kustomization.yaml` (added `secrets.yaml` resource).
- Requires a new Azure Key Vault secret (`renovate-git-private-key`) to be created before the first run.