### PR TITLE
(feat)renovate: use verified email for git author

### DIFF
--- a/kubernetes/infra/renovate/overlays/default/config.json
+++ b/kubernetes/infra/renovate/overlays/default/config.json
@@ -3,7 +3,7 @@
   "repositories": [
     "leehosanganson/homelab"
   ],
-  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
+  "gitAuthor": "Renovate Bot <renovate@leahosanganson.dev>",
   "onboarding": false,
   "requireConfig": "optional",
   "extends": [


### PR DESCRIPTION
## What
- Updates the `gitAuthor` email in the Renovate config from `bot@renovateapp.com` to `renovate@leahosanganson.dev`

## How to Test
- Verify the new email matches a verified identity on GitHub so Renovate's commits are marked as "verified"

## Impact
- Renovate's commit authorship will show as verified, improving trust in CI/CD pipelines and contributing to clearer audit trails