### PR TITLE
(chore)renovate: fix HelmRelease detection by updating flux managerFilePatterns

### DIFF
--- a/kubernetes/infra/renovate/overlays/default/config.json
+++ b/kubernetes/infra/renovate/overlays/default/config.json
@@ -51,7 +51,8 @@
   ],
   "flux": {
     "managerFilePatterns": [
-      "/^fluxcd/clusters/production/.+\\.ya?ml$/"
+      "/^fluxcd/clusters/production/.+\\.ya?ml$/",
+      "/kubernetes/.+/base/release\\.ya?ml$/"
     ]
   },
   "kubernetes": {


### PR DESCRIPTION
## What

Fixes Renovate's inability to detect Helm chart version updates in `HelmRelease` resources. The `flux` manager was configured with a `managerFilePatterns` that only matched files under `fluxcd/clusters/production/`, which contains FluxCD bootstrap manifests but no `HelmRelease` resources. HelmRelease files live under `kubernetes/*/base/release.yaml` and were therefore never seen by the flux manager.

This PR adds `/kubernetes/.+/base/release\.ya?ml$/` to the flux manager's `managerFilePatterns`, allowing Renovate to extract chart version dependencies from all 17 `HelmRelease` files in the repository (infrastructure, monitoring, and app HelmReleases).

## How to Test

1. Merge this PR into `main`.
2. The next scheduled Renovate CronJob run (~12 hours) will pick up the new config.
3. Check the Renovate pod logs (`kubectl logs -n renovate`) — look for:
   - `Matched N file(s) for manager flux` showing more files matched (previously 7, now should include HelmRelease files)
   - New dependency entries with proper datasources like `helm` or `docker` (not just `kubernetes-api`)
4. Verify that Renovate creates PRs for outdated Helm chart versions if any exist.

## Impact

- **Positive**: Renovate will now detect and create PRs for Helm chart version updates across all 17 `HelmRelease` resources (cert-manager, traefik, velero, rancher, harbor, metrics-server, external-secrets, gpu-operator, plus monitoring: alloy/grafana/loki/prometheus/uptime-kuma, apps: coder/immich/minecraft/zotero-webdav).
- **Scope**: Only affects Renovate's file-matching behavior. No Kubernetes manifests are changed.
- **Backwards compatible**: The existing `fluxcd/clusters/production/` pattern is preserved; the new pattern simply adds coverage.