### PR TITLE
chore/renovate: use global concurrency group for renovate-review queueing

### DIFF
--- a/.github/workflows/renovate-review.yml
+++ b/.github/workflows/renovate-review.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'none' }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary

Fixes the Renovate `renovate-review` GitHub Actions workflow so that all review runs queue one-after-another using a single global concurrency group.

The previous per-PR concurrency group (${{ github.workflow }}-${{ github.event.pull_request.number || 'none' }}) gave each PR its own concurrent slot, causing all Renovate batch updates to run in parallel instead of queuing.

## Changes
- Reverts `concurrency.group` from ${{ github.workflow }}-${{ github.event.pull_request.number || 'none' }} back to ${{ github.workflow }} (single global group)
- Keeps `cancel-in-progress: false` so queued runs are never cancelled, they simply wait their turn

## How it works now
When Renovate opens a batch of PRs (e.g., 10+ dependency updates):
1. The first `renovate-review` run starts immediately
2. All subsequent runs queue behind it
3. Each completes and the next one in line starts

This prevents overwhelming GitHub Actions runners and ensures every Renovate PR gets reviewed sequentially.

## Impact
- Fixes #243 (renovate-action not triggering properly)
- Every renovate-review run queues strictly one-after-another across all PRs