### PR TITLE
(feat)prometheus: increase retention to 90 days (~3 months)

### DIFF
--- a/kubernetes/monitoring/prometheus/overlays/default/values.yaml
+++ b/kubernetes/monitoring/prometheus/overlays/default/values.yaml
@@ -1,6 +1,6 @@
 server:
-  retention: 14d
-  retentionSize: 100GB
+  retention: 90d
+  retentionSize: 130GB
   securityContext:
     runAsUser: 65534
     runAsGroup: 65534


### PR DESCRIPTION
## What
Increase Prometheus retention period from 14 days to 90 days (approximately 3 months), and adjust the size-based retention limit from 100GB to 130GB to accommodate the longer retention window.

## How to Test
- After merge, FluxCD will reconcile the HelmRelease with updated values.
- Verify in Prometheus UI: `Settings → Admin → TSDB Status` for retention settings.
- Monitor `prometheus_tsdb_storage_bytes_total` metric and PVC usage over time.

## Impact
- Prometheus will retain ~3 months of historical metrics data instead of 14 days.
- Expected storage growth from ~14GB to ~126GB within the 150GiB PVC (based on current ~1.4 GB/day ingestion rate).