### PR TITLE
(feat) matter-server: deploy dedicated NixOS VM on pve01

### DIFF
--- a/nixos/flake.nix
+++ b/nixos/flake.nix
@@ -64,6 +64,16 @@
       ];
     };
 
+    nixosConfigurations.matter-server = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      specialArgs = { inherit inputs; inherit sops-secrets; };
+      modules = [
+        ./hosts/matter-server
+        disko.nixosModules.disko
+        sops-nix.nixosModules.sops
+      ];
+    };
+
     # Minimal NixOS installer ISO for Proxmox VM templates.
     # Build: nix build .#packages.x86_64-linux.installer
     # Upload the resulting ISO to Proxmox, then use provision.sh to install.

--- a/nixos/hosts/matter-server/default.nix
+++ b/nixos/hosts/matter-server/default.nix
@@ -1,0 +1,45 @@
+{ sops-secrets, ... }: {
+  imports = [
+    ../../modules/users.nix
+    ../../modules/matter-server.nix
+    ../../modules/disko.nix
+    ../../modules/sops-bootstrap.nix
+  ];
+
+  system.stateVersion = "26.05";
+
+  networking = {
+    hostName = "matter-server";
+    useDHCP = false;
+    usePredictableInterfaceNames = false;
+    interfaces.eth0.ipv4.addresses = [
+      {
+        address = "192.168.1.254";
+        prefixLength = 24;
+      }
+    ];
+    defaultGateway = "192.168.1.1";
+    nameservers = [ "192.168.1.132" ];
+    firewall.enable = true;
+  };
+
+  services.qemuGuest.enable = true;
+
+  # sops — no application secrets needed for Matter Server (self-contained)
+  sops = {
+    defaultSopsFile = "${sops-secrets}/secrets.yaml";
+    secrets = { };
+  };
+
+  # ssh
+  services.openssh = {
+    enable = true;
+    settings.PasswordAuthentication = false;
+    settings.PermitRootLogin = "prohibit-password";
+  };
+
+  services.resolved = {
+    enable = true;
+    settings.Resolve.DNSSEC = "false";
+  };
+}

--- a/nixos/modules/matter-server.nix
+++ b/nixos/modules/matter-server.nix
@@ -1,0 +1,13 @@
+{ config, pkgs, ... }:
+
+{
+  networking.firewall.allowedTCPPorts = [ 5580 ];
+
+  boot.kernel.sysctl = {
+    "net.ipv6.conf.all.forwarding" = 1;
+    "net.ipv6.conf.default.forwarding" = 1;
+    "net.netfilter.nf_conntrack_netlink.mtu" = 64;
+  };
+
+  services.matter-server.enable = true;
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -39,4 +39,12 @@ nodes = {
     disk_size = 40
     datastore = "local-lvm"
   }
+  "matter-server" = {
+    node      = "pve01"
+    vm_id     = 401
+    cores     = 1
+    memory    = 2048
+    disk_size = 15
+    datastore = "local-lvm"
+  }
 }


### PR DESCRIPTION
## What

Deploys a dedicated NixOS VM to run the python-matter-server service for Home Assistant Matter integration. Per issue #224, Matter integration requires high-fidelity mDNS discovery and IPv6 Route Information Options that are difficult to manage within Kubernetes CNIs. This VM runs natively on Proxmox (pve01) with direct network access.

VM Specs: 1 vCPU, 2GB RAM, 15GB disk on pve01 (vm_id: 401)
IP Address: 192.168.1.254/24

Files changed:
- terraform/terraform.tfvars - Added matter-server VM resource definition
- nixos/modules/matter-server.nix - New NixOS service module enabling Matter Server with port 5580, IPv6 forwarding, and sysctl tweaks for Thread Border Router visibility
- nixos/hosts/matter-server/default.nix - Host configuration with static networking, SSH, firewall, and SOPS bootstrap
- nixos/flake.nix - Registered matter-server as a new NixOS flake configuration

## How to Test

1. Build the NixOS installer ISO: nix build .#packages.x86_64-linux.installer -o /tmp/nixos-installer.iso and upload to Proxmox
2. Run terraform apply in terraform/ to create the VM on pve01 - this will auto-provision it via provision.sh
3. SSH into the VM and verify Matter Server is running: systemctl status matter-server
4. Test connectivity from a k3s pod to matter-server-ip:5580
5. Add the Matter integration in Home Assistant UI using the remote WebSocket URL (ws://192.168.1.254:5580)

## Impact

- New infrastructure on pve01 (minimal resource footprint)
- Enables Matter device commissioning via Home Assistant Mobile App over IP
- Requires IPv6 forwarding and clean mDNS - no NAT, no CNI overlay
- SSH host keys and sops secrets bootstrap need to be pre-generated before provisioning