### PR TITLE
fix(reviews): fix unexpanded PR metadata variables in renovate-review action

### DIFF
--- a/.github/workflows/renovate-review.yml
+++ b/.github/workflows/renovate-review.yml
@@ -43,10 +43,10 @@ jobs:
           PR_TITLE: "${{ steps.pr-details.outputs.title }}"
           PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          # Build the prompt. Static parts via single-quoted heredoc (no expansion),
-          # PR body appended directly from jq (bypasses shell variable interpolation).
+          # Build the prompt. PR metadata (${PR_NUM}, ${PR_TITLE}, ${PR_SHA}) expanded via
+          # unquoted heredoc; PR body appended separately via jq to avoid variable injection.
 
-          cat > pr-prompt.txt << 'PROMPT_HEADER'
+          cat > pr-prompt.txt << PROMPT_HEADER
           Review the following dependency update pull request and post a summary comment.
 
           Security rules:


### PR DESCRIPTION
## What

Fixes the `renovate-review` GitHub Action where the LLM agent received literal placeholder strings (`\`, `\`, `\`) instead of actual values. The action was using a single-quoted heredoc (<< 'PROMPT_HEADER') which disabled all variable expansion inside bash, so shell variables were never substituted into the prompt sent to opencode.

## How to Test

1. Create or synchronize a Renovate PR (branch prefixed with `renovate/`).
2. Check that the `renovate-review` action completes successfully.
3. Verify the LLM agent receives the actual PR number, title, and commit SHA instead of placeholder strings like `${PR_NUM}`.

## Impact

- **Files changed:** `.github/workflows/renovate-review.yml` (1 file)
- **Change:** Single-character edit — removed quotes from << 'PROMPT_HEADER' to make it << PROMPT_HEADER, enabling bash variable expansion. PR body is still appended separately via `jq` to maintain security against variable injection.