### PR TITLE
(chore)traefik: increase read/write/idle timeouts for large video uploads

### DIFF
--- a/kubernetes/infra/traefik/overlays/default/values.yaml
+++ b/kubernetes/infra/traefik/overlays/default/values.yaml
@@ -8,8 +8,18 @@ deployment:
 ports:
   web:
     exposedPort: 80
+    transport:
+      respondingTimeouts:
+        readTimeout: "3600"
+        writeTimeout: "3600"
+        idleTimeout: "3600"
   websecure:
     exposedPort: 443
+    transport:
+      respondingTimeouts:
+        readTimeout: "3600"
+        writeTimeout: "3600"
+        idleTimeout: "3600"
 service:
   ipFamilyPolicy: PreferDualStack
   spec:
@@ -37,6 +47,7 @@ tolerations:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
     operator: Exists
+
 env:
   - name: CF_DNS_API_TOKEN
     valueFrom:


### PR DESCRIPTION
## What

Increased Traefik `readTimeout`, `writeTimeout`, and `idleTimeout` to 3600 seconds (1 hour) on both `web` and `websecure` entrypoints. This fixes the "Request aborted" errors occurring when uploading large video files (>3-5 GB) to Immich.

## How to Test

1. After this PR is merged, wait for Flux to sync the change (~5 minutes).
2. Attempt to upload a large video file (e.g., 5 GB+) to Immich via the mobile app or web UI.
3. Verify in Traefik logs (`kubectl logs -n kube-system -l app.kubernetes.io/name=traefik`) that no timeout-related errors appear.
4. Verify Immich logs show successful upload completion instead of "Request aborted" errors.

## Impact

- **Fixes**: Large video uploads to Immich now complete without being prematurely terminated by Traefik's 60-second default `readTimeout`.
- **No breaking changes**: Only timeout values are increased; all other Traefik configuration remains unchanged.