### PR TITLE
(fix)renovate: remove ineffective minimumReleaseAge and fix opencode review workflow

### DIFF
--- a/.github/workflows/renovate-review.yml
+++ b/.github/workflows/renovate-review.yml
@@ -1,8 +1,12 @@
 name: renovate-review
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
+
+concurrency:
+  group: renovate-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   review-renovate-pr:
@@ -34,6 +38,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run OpenCode Review Agent
+        id: review
         env:
           LITELLM_KEY: ${{ secrets.LITELLM_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,3 +84,4 @@ jobs:
           # Pass prompt as positional argument (double-quoted preserves all special chars).
           PROMPT=$(cat pr-prompt.txt)
           opencode run --agent dependency-reviewer "$PROMPT"
+        continue-on-error: true

--- a/kubernetes/infra/renovate/overlays/default/config.json
+++ b/kubernetes/infra/renovate/overlays/default/config.json
@@ -13,8 +13,6 @@
   "pinDigests": true,
   "prHourlyLimit": 0,
   "prConcurrentLimit": 10,
-  "minimumReleaseAge": "14 days",
-  "minimumReleaseAgeBehaviour": "timestamp-optional",
   "internalChecksFilter": "flexible",
   "packageRules": [
     {


### PR DESCRIPTION
## What

Two fixes for Renovate bot issues identified through PR analysis:

1. **Remove `minimumReleaseAge` from Renovate config** — GHCR (`ghcr.io`) does not provide release timestamps, making the 14-day age gate ineffective. The `timestamp-optional` behavior was silently bypassing the safety buffer entirely for Docker images (the primary datasource). Per [Renovate docs](https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-registries-support-release-timestamps), GHCR is explicitly listed as ❌ unsupported for timestamps.

2. **Fix opencode review agent PR comments** — Switch `renovate-review.yml` from `pull_request_target` to `pull_request` trigger, add per-PR concurrency grouping (`renovate-review-${{ github.event.pull_request.number }}`), and add `continue-on-error: true`. This addresses the inconsistent PR comment posting where reviews appeared in GitHub Actions logs but not on the PR itself.

## How to Test

1. **Renovate config**: After merging, wait for Renovate's next run. Verify no "pending" status checks for minimum release age appear on Docker image PRs.
2. **Opencode review**: Any new Renovate PR will trigger the workflow. Check that a `github-actions` (dependency-reviewer) comment appears on the PR body within minutes.

## Impact

- **Low risk** — Removing `minimumReleaseAge` has no functional change since GHCR timestamps don't exist anyway. The age gate was already being bypassed.
- **Low risk** — Switching from `pull_request_target` to `pull_request` aligns with OpenCode's [official recommended pattern](https://opencode.ai/docs/github/#pull-request-example). Per-PR concurrency prevents duplicate comments on synchronize events.
