### PR TITLE
feat(litellm): set request_timeout to 600s

### DIFF
--- a/kubernetes/apps/litellm/overlays/default/config.yaml
+++ b/kubernetes/apps/litellm/overlays/default/config.yaml
@@ -7,5 +7,6 @@ data:
     litellm_settings:
       cache: True
       callbacks: ["prometheus"]
+      request_timeout: 600
       cache_params:
         type: local


### PR DESCRIPTION
## What

This sets LiteLLM's request timeout to 600 seconds, addressing timeout issues for long-running LLM completion calls on the internal network. The default LiteLLM timeout may be too short for large model completions, causing premature 408/504 errors. This change increases the timeout from the default (~30s) to 600s to accommodate extended generation times.

## How to Test

1. Make a long-running chat completion call through the Litellm ingress endpoint with a large model (e.g., `litellm/claude-sonnet-4-20250514` or similar)
2. Verify the request completes successfully without receiving a 408 Request Timeout or 504 Gateway Timeout error
3. For comparison, verify shorter calls still work as expected

## Impact

- Prevents premature LiteLLM timeouts for large model completions (increased from ~30s default to 600s)
- HAProxy client timeout of 50s becomes the effective outer bound for most requests; Traefik upstream timeout of 3600s remains as the absolute ceiling
- No changes to other LiteLLM settings or configuration