### PR TITLE
feat(grimmory): replace bookdrop PVC with NFS PV on nas1

### DIFF
--- a/kubernetes/apps/grimmory/base/pvc.yaml
+++ b/kubernetes/apps/grimmory/base/pvc.yaml
@@ -37,7 +37,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 5Gi
+      storage: 50Gi
   volumeName: grimmory-books-pv
 ---
 apiVersion: v1
@@ -47,7 +47,7 @@ metadata:
 spec:
   storageClassName: ""
   capacity:
-    storage: 50Gi
+    storage: 5Gi
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
@@ -68,5 +68,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 50Gi
+      storage: 5Gi
   volumeName: grimmory-bookdrop-pv

--- a/kubernetes/apps/grimmory/base/pvc.yaml
+++ b/kubernetes/apps/grimmory/base/pvc.yaml
@@ -41,12 +41,32 @@ spec:
   volumeName: grimmory-books-pv
 ---
 apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: grimmory-bookdrop-pv
+spec:
+  storageClassName: ""
+  capacity:
+    storage: 50Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: nas1.home.lab
+    path: /volume1/media/downloads/books
+  mountOptions:
+    - hard
+    - nfsvers=4.1
+---
+apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: grimmory-bookdrop-pvc
 spec:
+  storageClassName: ""
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 50Gi
+  volumeName: grimmory-bookdrop-pv

--- a/kubernetes/apps/grimmory/base/pvc.yaml
+++ b/kubernetes/apps/grimmory/base/pvc.yaml
@@ -37,7 +37,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 50Gi
+      storage: 5Gi
   volumeName: grimmory-books-pv
 ---
 apiVersion: v1


### PR DESCRIPTION
Replace auto-provisioned grimmory-bookdrop-pvc (1Gi) with a manual NFS PersistentVolume on nas1.home.lab:/volume1/media/downloads/books, following the pattern from media/base/data/downloads.yaml.