### PR TITLE
fix(qbittorrent): add writable /app volume for slskd sidecar

### DIFF
--- a/kubernetes/apps/media/base/qbittorrent/deployment.yaml
+++ b/kubernetes/apps/media/base/qbittorrent/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         app: qbittorrent
     spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -100,6 +103,8 @@ spec:
             - name: downloads
               mountPath: /app/downloads
               subPath: music
+            - name: slskd-app
+              mountPath: /app
       volumes:
         - name: downloads
           persistentVolumeClaim:
@@ -107,3 +112,6 @@ spec:
         - name: config
           persistentVolumeClaim:
             claimName: qbit-pvc
+        - name: slskd-app
+          emptyDir:
+            sizeLimit: 1Gi


### PR DESCRIPTION
## What

Fix the slskd sidecar in the qbittorrent pod, which is in CrashLoopBackOff because `/app` is not a mounted writable volume.

- Add an `emptyDir` volume `slskd-app` mounted at `/app` in the slskd container.
- Add a pod-level `securityContext` with `fsGroup: 1000` and `fsGroupChangePolicy: OnRootMismatch` so the slskd process (UID/GID 1000) can write to `/app` without triggering a recursive chown on the large `downloads` PVC.

## How to Test

1. `kustomize build kubernetes/apps/media/overlays/default` should succeed.
2. After the PR is merged and Flux reconciles, check the pod in the `media` namespace: `kubectl get pod -n media -l app=qbittorrent` should show `3/3` Ready.
3. Check slskd logs: `kubectl logs -n media -l app=qbittorrent -c slskd | tail` should show startup without the `/app` permission error.

## Impact

- The `slskd` local config/slskd.yml will be stored in an `emptyDir`, so it will be reset when the pod is recreated. This is acceptable because `SLSKD_REMOTE_CONFIGURATION=true` is already set.
- The large `downloads` PVC is not recursively chowned thanks to `fsGroupChangePolicy: OnRootMismatch`.
- The qBittorrent and gluetun containers are unaffected.