### PR TITLE
fix(monitoring): set Grafana deployment strategy to Recreate

### DIFF
--- a/kubernetes/monitoring/grafana/overlays/default/values.yaml
+++ b/kubernetes/monitoring/grafana/overlays/default/values.yaml
@@ -1,3 +1,6 @@
+deploymentStrategy:
+  type: Recreate
+
 persistence:
   enabled: true
   accessModes:


### PR DESCRIPTION
## What

Set the Grafana Deployment's `strategy` to `Recreate` so the old pod is terminated before the new one starts. This resolves the `Init:0/2` stuck state caused by a Multi-Attach error on the Synology CSI ReadWriteOnce PVC when pods are scheduled across different nodes during a RollingUpdate rollout.

## How to Test

1. After merge, monitor the Grafana Deployment rollout:
   ```bash
   kubectl rollout status deployment/grafana -n monitoring
   ```
2. Verify no `Init:0/2` state appears and the new pod starts cleanly.
3. Confirm the old pod is fully terminated before the new one begins mounting the PVC.

## Impact

- Changes Grafana Deployment strategy from `RollingUpdate` (default) to `Recreate`.
- Brief downtime during next rollout as the existing pod is killed before the new one starts.
- Eliminates repeated Multi-Attach errors and Init container failures on nodes without the PVC mounted.