### PR TITLE
feat(hermes-agent): add GitHub MCP server

### DIFF
--- a/nixos/flake.lock
+++ b/nixos/flake.lock
@@ -346,11 +346,11 @@
     "sops-secrets": {
       "flake": false,
       "locked": {
-        "lastModified": 1785613429,
-        "narHash": "sha256-Nqm2T9RZnYhe5o82X8fOUogFhU342Krfpqq2NWOwb6k=",
+        "lastModified": 1785617303,
+        "narHash": "sha256-Vy/5Ybre+x6CCueWqG7pMY1EmN8pLnQgMZWU0zGQrAI=",
         "ref": "main",
-        "rev": "70530b8ef335f3d87fb63a7e1449723ac11aa0ed",
-        "revCount": 33,
+        "rev": "c3fb47cdf9821ed43dc7c48efabcde256c8afb59",
+        "revCount": 35,
         "type": "git",
         "url": "ssh://git@github.com/leehosanganson/sops.git"
       },

--- a/nixos/modules/hermes-agent.nix
+++ b/nixos/modules/hermes-agent.nix
@@ -63,6 +63,13 @@ in
       model.provider = "opencode-go";
       model.default = "kimi-k2.7-code";
       toolsets = [ "all" ];
+      model_aliases = {
+        litellm-qwen = {
+          model = "unsloth/qwen-3.6";
+          provider = "custom";
+          base_url = "https://litellm.homelab.leehosanganson.dev/v1";
+        };
+      };
     };
 
     environmentFiles = [ config.sops.secrets."hermes-env".path ];

--- a/nixos/modules/hermes-agent.nix
+++ b/nixos/modules/hermes-agent.nix
@@ -67,6 +67,17 @@ in
 
     environmentFiles = [ config.sops.secrets."hermes-env".path ];
 
+    # GitHub MCP server — token is loaded from the sops-managed hermes-env.
+    mcpServers = {
+      github = {
+        command = "npx";
+        args = [ "-y" "@modelcontextprotocol/server-github" ];
+        env = {
+          GITHUB_PERSONAL_ACCESS_TOKEN = "\${GITHUB_PERSONAL_ACCESS_TOKEN}";
+        };
+      };
+    };
+
     # Common tools available to the agent's terminal backend.
     extraPackages = with pkgs; [ git jq ripgrep ffmpeg nodejs kubectl kubernetes-helm ];
   };


### PR DESCRIPTION
## What
Wire the GitHub MCP server and a self-hosted LiteLLM model alias into the Hermes Agent NixOS module.
- GitHub MCP server uses the official `@modelcontextprotocol/server-github` package.
- The GitHub PAT is kept in the sops-managed `hermes-env` secret and is referenced via `\${GITHUB_PERSONAL_ACCESS_TOKEN}` env-var interpolation in the generated config.yaml.
-  A new `litellm-qwen` model alias points at the self-hosted LiteLLM proxy at `https://litellm.homelab.leehosanganson.dev/v1`, using the existing `OPENAI_API_KEY` in `hermes-env`.

## How to test\n\n1. `nix flake check` passes (already verified).\n2. After merging, deploy with updated secrets:
```bash
./nixos/scripts/rebuild.sh --update-secrets hermes-agent 192.168.1.27
```
3. In Discord, run `/tools` or `/status` and confirm `mcp_github_*` tools appear.
4. In Discord, run `/model litellm-qwen` to switch to the self-hosted Qwen model.

## Impact
- No breaking changes; default model remains `opencode-go/kimi-k2.7-code`.
- Adds `mcp_github_*` tools and an optional local model alias.
- Requires `GITHUB_PERSONAL_ACCESS_TOKEN` and `OPENAI_API_KEY` to be present in the sops-secrets `hermes-env` file (already done).