### PR TITLE
fix(monitoring): switch Garage to official v2.3.0 chart via GitRepository

### DIFF
--- a/kubernetes/infra/helm/garage.yaml
+++ b/kubernetes/infra/helm/garage.yaml
@@ -1,7 +1,9 @@
 apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
+kind: GitRepository
 metadata:
   name: garage
 spec:
   interval: 1h
-  url: https://geekxflood.github.io/helm-charts
+  url: https://git.deuxfleurs.fr/Deuxfleurs/garage.git
+  ref:
+    tag: v2.3.0

--- a/kubernetes/monitoring/garage/base/release.yaml
+++ b/kubernetes/monitoring/garage/base/release.yaml
@@ -6,10 +6,9 @@ spec:
   interval: 1h
   chart:
     spec:
-      chart: garage
-      version: 1.1.1
+      chart: ./script/helm/garage
       sourceRef:
-        kind: HelmRepository
+        kind: GitRepository
         name: garage
         namespace: flux-system
   valuesFrom:

--- a/kubernetes/monitoring/garage/overlays/default/secrets.yaml
+++ b/kubernetes/monitoring/garage/overlays/default/secrets.yaml
@@ -11,6 +11,6 @@ spec:
     name: garage-rpc-credentials
     creationPolicy: Owner
   data:
-    - secretKey: rpc-secret
+    - secretKey: rpcSecret
       remoteRef:
         key: garage-rpc-secret

--- a/kubernetes/monitoring/garage/overlays/default/values.yaml
+++ b/kubernetes/monitoring/garage/overlays/default/values.yaml
@@ -1,25 +1,16 @@
 garage:
-  # Use a single replica for the homelab deployment (no redundancy).
-  replicationMode: "1"
+  # Single-node homelab deployment (no redundancy).
+  replicationFactor: "1"
+  consistencyMode: "consistent"
 
-  # Placeholder: the real RPC secret is injected via the GARAGE_RPC_SECRET
-  # environment variable from the garage-rpc-credentials secret.
-  rpcSecret: "REPLACE_ME_WITH_GARAGE_RPC_SECRET"
+  # Use the ExternalSecret-created secret instead of the chart-generated one.
+  existingRpcSecret: garage-rpc-credentials
 
   s3:
     api:
       region: garage
     web:
       rootDomain: ".web.garage.tld"
-
-  # Override the RPC secret from an ExternalSecret at runtime.
-  # The chart's own generated secret keeps the placeholder and is unused.
-environment:
-  - name: GARAGE_RPC_SECRET
-    valueFrom:
-      secretKeyRef:
-        name: garage-rpc-credentials
-        key: rpc-secret
 
 # Single-node StatefulSet.
 deployment:


### PR DESCRIPTION
## What

The community `geekxflood/garage` Helm chart renders a `garage.toml` that uses the legacy `replication_mode` setting, which Garage v2.3.0 rejects at startup with:

```
The legacy replication_mode is no longer supported. Use replication_factor and consistency_mode
```

This PR switches the deployment to the official Garage Helm chart from the upstream repository (tag `v2.3.0`) via a Flux `GitRepository` source, and updates the values to use the new `replicationFactor` / `consistencyMode` settings.

- Replaces the `geekxflood` HelmRepository with a `GitRepository` pointing to `https://git.deuxfleurs.fr/Deuxfleurs/garage.git` (tag `v2.3.0`).
- Updates the `garage` HelmRelease to use `chart: ./script/helm/garage` from that GitRepository.
- Updates `values.yaml` to set `replicationFactor: "1"`, `consistencyMode: "consistent"`, and `existingRpcSecret: garage-rpc-credentials` (matching the official chart's secret key name).

## How to Test

1. Run `kustomize build kubernetes/monitoring/garage/overlays/default` and verify it renders a `GitRepository`, `HelmRelease`, `ExternalSecret`, and `ConfigMap`.
2. Run `helm template` against the official chart at `./script/helm/garage` with the overlay values and confirm the generated `garage.toml` contains `replication_factor = 1` and `consistency_mode = "consistent"` (no `replication_mode`).
3. After merge, ensure the `garage-rpc-secret` exists in Key Vault and reconcile the `garage` HelmRelease.

## Impact

- The Garage daemon will now start with a config that Garage v2.3.0 accepts.
- The source is the official Garage chart instead of a community wrapper.
- No data migration is needed because Garage has not successfully started yet.
- The RPC secret is still sourced from the same `garage-rpc-secret` Key Vault key via ExternalSecret.
