### PR TITLE
feat(monitoring): deploy Garage UI web dashboard

### DIFF
--- a/kubernetes/infra/helm/garage-ui.yaml
+++ b/kubernetes/infra/helm/garage-ui.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: garage-ui
+spec:
+  interval: 1h
+  url: https://helm.noste.dev

--- a/kubernetes/infra/helm/kustomization.yaml
+++ b/kubernetes/infra/helm/kustomization.yaml
@@ -17,4 +17,5 @@ resources:
   - grafana.yaml
   - grafana-community.yaml
   - garage.yaml
+  - garage-ui.yaml
   - prometheus-community.yaml

--- a/kubernetes/monitoring/garage-ui/base/kustomization.yaml
+++ b/kubernetes/monitoring/garage-ui/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - release.yaml

--- a/kubernetes/monitoring/garage-ui/base/release.yaml
+++ b/kubernetes/monitoring/garage-ui/base/release.yaml
@@ -1,0 +1,17 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: garage-ui
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: garage-ui
+      version: 0.11.1
+      sourceRef:
+        kind: HelmRepository
+        name: garage-ui
+        namespace: flux-system
+  valuesFrom:
+    - kind: ConfigMap
+      name: garage-ui-values

--- a/kubernetes/monitoring/garage-ui/overlays/default/kustomization.yaml
+++ b/kubernetes/monitoring/garage-ui/overlays/default/kustomization.yaml
@@ -1,0 +1,11 @@
+namespace: monitoring
+
+resources:
+  - ../../base
+
+configMapGenerator:
+  - files:
+      - values.yaml
+    name: garage-ui-values
+    options:
+      disableNameSuffixHash: true

--- a/kubernetes/monitoring/garage-ui/overlays/default/values.yaml
+++ b/kubernetes/monitoring/garage-ui/overlays/default/values.yaml
@@ -1,0 +1,63 @@
+replicaCount: 1
+
+config:
+  server:
+    host: "0.0.0.0"
+    port: 8080
+    environment: "production"
+    domain: "garage-ui.homelab.leehosanganson.dev"
+    protocol: "https"
+    root_url: "https://garage-ui.homelab.leehosanganson.dev"
+
+  garage:
+    endpoint: "http://garage.monitoring.svc.cluster.local:3900"
+    region: "garage"
+    # Use the headless metrics service Garage already creates for the admin API.
+    admin_endpoint: "http://garage-metrics.monitoring.svc.cluster.local:3903"
+    # Leave empty so Garage UI prompts for the Garage admin token at login.
+    admin_token: ""
+
+  # Token auth is enabled when no other auth method is configured.
+  auth:
+    metrics_public: false
+    admin:
+      enabled: false
+    oidc:
+      enabled: false
+
+  logging:
+    level: "info"
+    format: "json"
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  className: "traefik"
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-cloudflare"
+  hosts:
+    - host: garage-ui.homelab.leehosanganson.dev
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: garage-ui-tls
+      hosts:
+        - garage-ui.homelab.leehosanganson.dev
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+serviceMonitor:
+  enabled: false
+
+networkPolicy:
+  enabled: false

--- a/kubernetes/monitoring/overlays/production/kustomization.yaml
+++ b/kubernetes/monitoring/overlays/production/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
   - namespace.yaml
   - ../../garage/overlays/default
+  - ../../garage-ui/overlays/default
   - ../../uptime-kuma/overlays/default
   - ../../prometheus/overlays/default
   - ../../loki/overlays/default


### PR DESCRIPTION
## What

Deploys [Garage UI](https://github.com/Noooste/garage-ui), a web dashboard for managing Garage S3 object storage, in the `monitoring` namespace.

- Adds the `garage-ui` HelmRepository (`https://helm.noste.dev`).
- Adds a `garage-ui` HelmRelease using chart version `0.11.1`.
- Configures the UI to talk to the in-cluster Garage service:
  - S3 endpoint: `http://garage.monitoring.svc.cluster.local:3900`
  - Admin endpoint: `http://garage-metrics.monitoring.svc.cluster.local:3903` (reuses the headless metrics service Garage already creates on port 3903)
- Enables Traefik ingress with TLS via cert-manager at `https://garage-ui.homelab.leehosanganson.dev`.
- Leaves `admin_token` empty so Garage UI prompts for the Garage admin token at login (no extra secrets needed in Git).

## How to Test

1. Run `kustomize build kubernetes/monitoring/garage-ui/overlays/default` and confirm it renders a `HelmRelease` and `ConfigMap`.
2. Run `helm template` against `garage-ui/garage-ui` with the overlay values and verify the generated `config.yaml` points at the correct Garage endpoints and the Ingress uses the expected host.
3. After merge, reconcile the `garage-ui` HelmRelease and open `https://garage-ui.homelab.leehosanganson.dev`.

## Impact

- Adds another workload to the monitoring namespace.
- The Garage admin API is reachable internally through the existing `garage-metrics` headless service; no additional Service is required.
- Authentication is handled by Garage's built-in token login, so the Garage admin token must be entered on first use. If you prefer password/OIDC auth, update `config.auth` in the overlay values.
- DNS and TLS rely on the existing Traefik + cert-manager setup.
