### PR TITLE
fix(loki): move extraEnvFrom under defaults for Helm chart rendering

### DIFF
--- a/kubernetes/monitoring/loki/overlays/default/values.yaml
+++ b/kubernetes/monitoring/loki/overlays/default/values.yaml
@@ -34,15 +34,16 @@ loki:
       accessKeyId: $(LOKI_S3_ACCESS_KEY_ID)
       secretAccessKey: $(LOKI_S3_SECRET_ACCESS_KEY)
 
-  extraEnvFrom:
-    - secretRef:
-        name: loki-garage-s3-credentials
-
   compactor:
     compaction_interval: 30m
     retention_enabled: true
     retention_delete_delay: 2h
     delete_request_store: s3
+
+defaults:
+  extraEnvFrom:
+    - secretRef:
+        name: loki-garage-s3-credentials
 
 # SingleBinary was renamed to Monolithic in chart v18.
 deploymentMode: Monolithic


### PR DESCRIPTION
## What

Fix Loki pod CrashLoopBackOff by moving `extraEnvFrom` to the correct nesting level in the Helm chart values.

## Root Cause

The Loki HelmRelease had `extraEnvFrom:` at the top level of `values.yaml`, which the Helm chart ignores. The chart requires env var injections under `defaults.extraEnvFrom`. Without the S3 credentials being injected into the container, Loki falls back to dummy credentials, causing:

```
AuthorizationHeaderMalformed: unexpected scope: '20260801/dummy/s3/aws4_request', expected: '20260801/garage/s3/aws4_request'
init compactor: failed to init delete store
```

## How to Test

After this PR merges and Flux reconciles, check that the Loki pod starts successfully:

```bash
kubectl get pods -n monitoring | grep loki-0
kubectl logs -n monitoring loki-0 --tail=20  # should show startup without S3 errors
```

## Impact

- Fixes Loki pod deployment — restores centralized log collection for all cluster workloads
- No other manifests changed; purely a values.yaml structural fix
