### PR TITLE
fix(hermes): use named custom provider for litellm auth

### DIFF
--- a/nixos/modules/hermes-agent.nix
+++ b/nixos/modules/hermes-agent.nix
@@ -62,15 +62,21 @@ in
     settings = {
       model = {
         default = "unsloth/qwen-3.6";
-        provider = "custom";
-        base_url = "https://litellm.homelab.leehosanganson.dev";
+        provider = "litellm";
       };
       toolsets = [ "all" ];
+      providers = {
+        litellm = {
+          name = "litellm";
+          api = "https://litellm.homelab.leehosanganson.dev/v1";
+          key_env = "OPENAI_API_KEY";
+          default_model = "unsloth/qwen-3.6";
+        };
+      };
       model_aliases = {
         qwen = {
           model = "unsloth/qwen-3.6";
-          provider = "custom";
-          base_url = "https://litellm.homelab.leehosanganson.dev";
+          provider = "litellm";
         };
         kimi = {
           model = "kimi-k2.7-code";


### PR DESCRIPTION
## What

Replace the bare `provider = "custom"` configuration in hermes-agent with a named `litellm` custom provider. This ensures that the sops-managed `OPENAI_API_KEY` secret is correctly resolved by the Hermes runtime, fixing the authentication error where LiteLLM rejected requests with the placeholder key `"no-k****ired"`.

Changes:
- Set `model.provider = "litellm"` (named provider) instead of bare `"custom"`.
- Add `providers.litellm` block with `api`, `key_env = "OPENAI_API_KEY"`, and `default_model`.
- Update `model_aliases.qwen` to use `provider = "litellm"` (removed redundant `base_url`).
- Removed all bare `base_url` fields from `model` and aliases — the endpoint is now defined once in `providers.litellm.api`.

## How to Test

1. After this PR merges and FluxCD syncs, verify the hermes-agent pod on the `hermes-agent` host (192.168.1.27) starts without the `LiteLLM Virtual Key expected` error in its logs.
2. Confirm model resolution works by sending a test message to the agent via Discord or SSH (`/model` should resolve `unsloth/qwen-3.6` through the litellm provider).
3. Check that `OPENAI_API_KEY` is loaded from the sops-managed `hermes-env` secret and passed correctly to the litellm provider resolver.

## Impact

- **Risk**: Low — this is a configuration-only change within the existing NixOS module. No new packages or services are introduced.
- **Scope**: Only affects the hermes-agent service on the `hermes-agent` NixOS VM.
- **Trade-off**: The endpoint URL is now centralized in `providers.litellm.api` instead of duplicated across `model.base_url` and aliases. Future endpoint changes only require editing one location.