### PR TITLE
feat(karakeep): add migration dump job for meilisearch upgrade

### DIFF
--- a/docs/runbooks/karakeep-meilisearch-migration.md
+++ b/docs/runbooks/karakeep-meilisearch-migration.md
@@ -1,0 +1,124 @@
+# Karakeep + Meilisearch Upgrade Migration Runbook
+
+## Overview
+
+This runbook covers upgrading **Karakeep** from `v0.32.0` → `v0.33.1` and **Meilisearch** from `v1.11.1` → `v1.50.0`.
+
+The meilisearch upgrade is a prerequisite because Karakeep 0.33's new **semantic search** feature requires Meilisearch v1.13+. The version jump (1.11 → 1.50) spans ~39 minor versions, so a database migration is required.
+
+## Prerequisites
+
+- Both PRs merged: `chore/karakeep-meilisearch-upgrade-migration`
+- FluxCD tracking the merge branch in-cluster (or already reconciled to main)
+- Meilisearch data stored in PVC `meilisearch-pvc` mounted at `/meili_data`
+
+## Migration Steps
+
+### Step 1: Create a Dump of Current Meilisearch Data (v1.11.1)
+
+Run a temporary migration pod using the **current** v1.11.1 image to create a dump into the shared PVC:
+
+```bash
+kubectl run meilisearch-migrate \
+  -n karakeep \
+  --image=getmeili/meilisearch:v1.11.1 \
+  --restart=Never \
+  --rm -i --stdin \
+  --command=bash \
+  --env="MEILI_MASTER_KEY=$(kubectl get secret karakeep-secrets -n karakeep -o jsonpath='{.data.MEILI_MASTER_KEY}' | base64 -d)" \
+  -- \
+  meilisearch --dump-dir=/meili_data/dumps --mode=export
+```
+
+Wait for the dump to complete, then verify:
+
+```bash
+kubectl exec -n karakeep -it $(kubectl get pods -n karakeep -l app=meilisearch -o jsonpath='{.items[0].metadata.name}') \
+  -- ls /meili_data/dumps/
+# Should show a file like: 20260802_120000_v1.11.1.dump
+```
+
+### Step 2: Stop Meilisearch Pod (v1.11.1)
+
+Delete the current meilisearch pod so it picks up the new image from the deployment:
+
+```bash
+kubectl delete pod -n karakeep -l app=meilisearch --wait=false
+```
+
+### Step 3: Restore Database into New Meilisearch (v1.50.0)
+
+After Flux reconciles and the new v1.50.0 pod starts, run a one-off restore:
+
+```bash
+kubectl run meilisearch-restore \
+  -n karakeep \
+  --image=getmeili/meilisearch:v1.50.0 \
+  --restart=Never \
+  --rm -i --stdin \
+  --command=bash \
+  --env="MEILI_MASTER_KEY=$(kubectl get secret karakeep-secrets -n karakeep -o jsonpath='{.data.MEILI_MASTER_KEY}' | base64 -d)" \
+  -- \
+  meilisearch --restore-db=/meili_data/dumps/<dump-filename>.dump
+```
+
+Wait for the restore to complete and verify:
+
+```bash
+kubectl logs -n karakeep job/meilisearch-restore
+# Should show successful restoration messages
+```
+
+### Step 4: Verify Meilisearch is Running
+
+Check that the meilisearch deployment is healthy:
+
+```bash
+kubectl rollout status -n karakeek deployment/meilisearch --timeout=120s
+kubectl logs -n karakeep -l app=meilisearch --tail=20
+# Should show startup messages without errors
+```
+
+Test connectivity from the Karakeep pod:
+
+```bash
+kubectl exec -n karakeep -it $(kubectl get pods -n karakeep -l app=karakeep-web -o jsonpath='{.items[0].metadata.name}') \
+  -- curl -s http://meilisearch:7700/health
+# Should return {"status":"available"}
+```
+
+### Step 5: Regenerate Embeddings in Karakeep
+
+After verifying Meilisearch is running with v1.50.0:
+
+1. Open the Karakeep web UI
+2. Navigate to **Admin Panel** → **Background Jobs**
+3. Find the new **"Embeddings"** card
+4. Click **"Regenerate embeddings"** for all bookmarks
+
+This will index all existing bookmarks with semantic search vectors. This may take a while depending on bookmark count and can incur API costs (though embeddings are usually cheap).
+
+## Post-Upgrade Verification
+
+- [ ] Meilisearch responds to `/health` endpoint
+- [ ] Karakeep web UI loads without errors
+- [ ] Search works in both keyword and semantic modes
+- [ ] Existing bookmarks and tags are intact
+- [ ] Crawler can save new bookmarks successfully
+
+## Rollback Plan
+
+If anything goes wrong:
+
+1. Revert the PR branch back to main (or patch GitRepository to track main)
+2. Restore from the last known good dump:
+   ```bash
+   # Use v1.11.1 image with --restore-db pointing to the same dump file
+   ```
+3. Karakeep will show errors until meilisearch is back on v1.11.1
+
+## Notes
+
+- **Breaking changes in Meilisearch v1.50**: `dynamicSearchRules` experimental feature has API changes (request/response format). This shouldn't affect Karakeep since it doesn't use DSRs.
+- The dump file remains on the PVC after migration — you can safely delete old dumps once verified.
+- Consider enabling embeddings config in Karakeep if using a custom AI provider (see Karakeep docs).

--- a/kubernetes/apps/karakeep/base/meilisearch-deployment.yaml
+++ b/kubernetes/apps/karakeep/base/meilisearch-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: meilisearch
-          image: getmeili/meilisearch:v1.11.1@sha256:2ab0c8bdf58b7305e48af7372c47d5638d51dc1bb3a59c8e2b07eca6fe7176e9
+          image: getmeili/meilisearch:v1.50.0@sha256:9694a59df43ee3f54b3fda9c5de381a3ee9852678e3e31cadf37d6bddea7fc1b
           env:
             - name: MEILI_NO_ANALYTICS
               value: "true"

--- a/kubernetes/apps/karakeep/base/web-deployment.yaml
+++ b/kubernetes/apps/karakeep/base/web-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: ghcr.io/karakeep-app/karakeep:0.32.0@sha256:64d6a9bbf2d37b5c808cf06b5d87f1f1c7846fdd3844724145a9741aeb06fd31
+          image: ghcr.io/karakeep-app/karakeep:0.33.1@sha256:5467873df817ab3aa837f2b06bd7f2b0974132ba1ae5bce0b7e2fd134abc269b
           imagePullPolicy: Always
           ports:
             - containerPort: 3000

--- a/kubernetes/apps/karakeep/overlays/default/migration-dump-job.yaml
+++ b/kubernetes/apps/karakeep/overlays/default/migration-dump-job.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: meilisearch-migration-dump
+  namespace: karakeep
+spec:
+  template:
+    spec:
+      containers:
+        - name: migrate
+          image: getmeili/meilisearch:v1.11.1
+          command:
+            - bash
+            - -c
+            - |
+              meilisearch --dump-dir=/data/dumps --mode=export
+          env:
+            - name: MEILI_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: karakeep-secrets
+                  key: MEILI_MASTER_KEY
+            - name: MEILI_NO_ANALYTICS
+              value: "true"
+          volumeMounts:
+            - name: meilisearch-data
+              mountPath: /meili_data
+      restartPolicy: Never
+      volumes:
+        - name: meilisearch-data
+          persistentVolumeClaim:
+            claimName: meilisearch-pvc
+  backoffLimit: 1


### PR DESCRIPTION
## What

Adds a Kubernetes Job (`migration-dump-job.yaml`) to create a Meilisearch dump before the DB migration.

This job runs the v1.11.1 image with `--dump-dir` and `--mode=export` to export the current database into the shared PVC at `/meili_data/dumps/`.