### PR TITLE
feat(monitoring): enable cert-manager TLS for metrics-server

### DIFF
--- a/kubernetes/infra/metrics-server/overlays/default/values.yaml
+++ b/kubernetes/infra/metrics-server/overlays/default/values.yaml
@@ -1,6 +1,9 @@
 args:
-  - --kubelet-insecure-tls
   - --kubelet-preferred-address-types=InternalIP
   - --metric-resolution=15s
+apiService:
+  insecureSkipTLSVerify: false
 extraArgs:
   - --kubelet-use-node-status-port
+tls:
+  type: cert-manager


### PR DESCRIPTION
## What

Properly configure TLS certificates for the metrics-server using cert-manager, replacing the insecure `--kubelet-insecure-tls` flag.

This eliminates the use of insecure TLS verification and ensures all kubelet API connections from metrics-server are properly certificate-authenticated.

- Remove `--kubelet-insecure-tls` flag (no longer needed with proper TLS)
- Set `apiService.insecureSkipTLSVerify: false` to enforce TLS verification
- Set `tls.type: cert-manager` to use cert-manager for certificate provisioning

## How to Test

1. After this PR merges, Flux will reconcile the changes and deploy the updated HelmRelease
2. cert-manager will create a self-signed Issuer and Certificate in the `kube-system` namespace
3. The APIService resource will get the `cert-manager.io/inject-ca-from` annotation for automatic CA bundle injection
4. Verify metrics-server pods are running: `kubectl get pods -n kube-system -l app.kubernetes.io/name=metrics-server`
5. Verify `kubectl top nodes` works and returns node metrics
6. Check cert-manager Certificate status: `kubectl get certificate -n kube-system metrics-server`

## Impact

- **Risk**: Low — this is a standard TLS configuration improvement with no functional changes to metrics-server behavior
- **Notes for reviewers**: The chart's cert-manager TLS type automatically handles the Issuer (self-signed) and Certificate resources. The CA injector annotation ensures the APIService gets the correct CA bundle without manual management.