### PR TITLE
fix(monitoring): add :9090 port to Grafana Prometheus datasource URL

### DIFF
--- a/kubernetes/monitoring/grafana/overlays/default/values.yaml
+++ b/kubernetes/monitoring/grafana/overlays/default/values.yaml
@@ -19,7 +19,7 @@ datasources:
       - name: Prometheus
         type: prometheus
         uid: prometheus
-        url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local
+        url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
         access: proxy
         isDefault: true
         jsonData:


### PR DESCRIPTION
## What

Fix Grafana's Prometheus datasource so it can actually reach the new kube-prometheus-stack Prometheus.

- The operator-managed `kube-prometheus-stack-prometheus` service listens on **9090** (and 8080 for the reloader), not port 80.
- The datasource URL was `http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local` (no port), so Grafana defaulted to **:80**, which has no listener → every `/api/v1/...` request timed out (`dial tcp 10.43.143.249:80: i/o timeout`).
- Result: the Datasource **Test** button shows a plugin error and all dashboards return empty.

Change: append `:9090` to the Prometheus datasource URL.

(The legacy `prometheus-server` Service exposed port 80→9090, which is why a port-less URL worked before the operator migration.)

## How to Test

1. After Flux reconciles, Grafana re-provisions the datasource.
2. Datasource page → Prometheus → **Test** returns success.
3. Dashboards (node, and the litellm dashboard) render data.

## Impact

- Single-character-port fix, no resource renames, no metric impact.
- Only Grafana's datasource provisioning ConfigMap changes.