### PR TITLE
chore(monitoring): make Flux watch externalized HelmRelease values

### DIFF
--- a/kubernetes/apps/coder/base/release.yaml
+++ b/kubernetes/apps/coder/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: coder
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: coder

--- a/kubernetes/apps/coder/overlays/default/kustomization.yaml
+++ b/kubernetes/apps/coder/overlays/default/kustomization.yaml
@@ -12,3 +12,5 @@ configMapGenerator:
     name: coder-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/apps/immich/base/release.yaml
+++ b/kubernetes/apps/immich/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: immich
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: immich

--- a/kubernetes/apps/immich/overlays/default/kustomization.yaml
+++ b/kubernetes/apps/immich/overlays/default/kustomization.yaml
@@ -12,3 +12,5 @@ configMapGenerator:
     name: immich-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/apps/minecraft/base/release.yaml
+++ b/kubernetes/apps/minecraft/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: minecraft1
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: minecraft

--- a/kubernetes/apps/minecraft/overlays/default/kustomization.yaml
+++ b/kubernetes/apps/minecraft/overlays/default/kustomization.yaml
@@ -9,3 +9,5 @@ configMapGenerator:
     name: minecraft1-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/apps/zotero-webdav/base/release.yaml
+++ b/kubernetes/apps/zotero-webdav/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: zotero-webdav
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: webdav

--- a/kubernetes/apps/zotero-webdav/overlays/default/kustomization.yaml
+++ b/kubernetes/apps/zotero-webdav/overlays/default/kustomization.yaml
@@ -10,3 +10,5 @@ configMapGenerator:
     name: zotero-webdav-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/infra/cert-manager/base/release.yaml
+++ b/kubernetes/infra/cert-manager/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: cert-manager
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: cert-manager

--- a/kubernetes/infra/cert-manager/overlays/default/kustomization.yaml
+++ b/kubernetes/infra/cert-manager/overlays/default/kustomization.yaml
@@ -11,3 +11,5 @@ configMapGenerator:
     name: cert-manager-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/infra/gpu-operator/base/release.yaml
+++ b/kubernetes/infra/gpu-operator/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: gpu-operator
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: gpu-operator

--- a/kubernetes/infra/gpu-operator/overlays/default/kustomization.yaml
+++ b/kubernetes/infra/gpu-operator/overlays/default/kustomization.yaml
@@ -10,3 +10,5 @@ configMapGenerator:
     name: gpu-operator-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/infra/harbor/base/release.yaml
+++ b/kubernetes/infra/harbor/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: harbor
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: harbor

--- a/kubernetes/infra/harbor/overlays/default/kustomization.yaml
+++ b/kubernetes/infra/harbor/overlays/default/kustomization.yaml
@@ -11,3 +11,5 @@ configMapGenerator:
     name: harbor-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/infra/metrics-server/base/release.yaml
+++ b/kubernetes/infra/metrics-server/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: metrics-server
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: metrics-server

--- a/kubernetes/infra/metrics-server/overlays/default/kustomization.yaml
+++ b/kubernetes/infra/metrics-server/overlays/default/kustomization.yaml
@@ -9,3 +9,5 @@ configMapGenerator:
     name: metrics-server-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/infra/rancher/base/release.yaml
+++ b/kubernetes/infra/rancher/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: rancher
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: rancher

--- a/kubernetes/infra/rancher/overlays/default/kustomization.yaml
+++ b/kubernetes/infra/rancher/overlays/default/kustomization.yaml
@@ -10,3 +10,5 @@ configMapGenerator:
     name: rancher-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/infra/traefik/base/release.yaml
+++ b/kubernetes/infra/traefik/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: traefik
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: traefik

--- a/kubernetes/infra/traefik/overlays/default/kustomization.yaml
+++ b/kubernetes/infra/traefik/overlays/default/kustomization.yaml
@@ -10,3 +10,5 @@ configMapGenerator:
     name: traefik-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/infra/velero/base/release.yaml
+++ b/kubernetes/infra/velero/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: velero
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: velero

--- a/kubernetes/infra/velero/overlays/default/kustomization.yaml
+++ b/kubernetes/infra/velero/overlays/default/kustomization.yaml
@@ -12,3 +12,5 @@ configMapGenerator:
     name: velero-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/monitoring/alloy/base/release.yaml
+++ b/kubernetes/monitoring/alloy/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: alloy
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: alloy

--- a/kubernetes/monitoring/alloy/overlays/default/kustomization.yaml
+++ b/kubernetes/monitoring/alloy/overlays/default/kustomization.yaml
@@ -9,3 +9,5 @@ configMapGenerator:
     name: alloy-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/monitoring/garage-ui/base/release.yaml
+++ b/kubernetes/monitoring/garage-ui/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: garage-ui
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: garage-ui

--- a/kubernetes/monitoring/garage-ui/overlays/default/kustomization.yaml
+++ b/kubernetes/monitoring/garage-ui/overlays/default/kustomization.yaml
@@ -10,3 +10,5 @@ configMapGenerator:
     name: garage-ui-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/monitoring/garage/base/release.yaml
+++ b/kubernetes/monitoring/garage/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: garage
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: ./script/helm/garage

--- a/kubernetes/monitoring/garage/overlays/default/kustomization.yaml
+++ b/kubernetes/monitoring/garage/overlays/default/kustomization.yaml
@@ -10,3 +10,5 @@ configMapGenerator:
     name: garage-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/monitoring/grafana/base/release.yaml
+++ b/kubernetes/monitoring/grafana/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: grafana
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: grafana

--- a/kubernetes/monitoring/grafana/overlays/default/kustomization.yaml
+++ b/kubernetes/monitoring/grafana/overlays/default/kustomization.yaml
@@ -10,3 +10,5 @@ configMapGenerator:
     name: grafana-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/monitoring/loki/base/release.yaml
+++ b/kubernetes/monitoring/loki/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: loki
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: loki

--- a/kubernetes/monitoring/loki/overlays/default/kustomization.yaml
+++ b/kubernetes/monitoring/loki/overlays/default/kustomization.yaml
@@ -10,3 +10,5 @@ configMapGenerator:
     name: loki-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/monitoring/prometheus/base/release.yaml
+++ b/kubernetes/monitoring/prometheus/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: kube-prometheus-stack
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: kube-prometheus-stack

--- a/kubernetes/monitoring/prometheus/overlays/default/kustomization.yaml
+++ b/kubernetes/monitoring/prometheus/overlays/default/kustomization.yaml
@@ -9,3 +9,5 @@ configMapGenerator:
     name: prometheus-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"

--- a/kubernetes/monitoring/uptime-kuma/base/release.yaml
+++ b/kubernetes/monitoring/uptime-kuma/base/release.yaml
@@ -3,7 +3,7 @@ kind: HelmRelease
 metadata:
   name: uptime-kuma
 spec:
-  interval: 1h
+  interval: 1m
   chart:
     spec:
       chart: uptime-kuma

--- a/kubernetes/monitoring/uptime-kuma/overlays/default/kustomization.yaml
+++ b/kubernetes/monitoring/uptime-kuma/overlays/default/kustomization.yaml
@@ -9,3 +9,5 @@ configMapGenerator:
     name: uptime-kuma-values
     options:
       disableNameSuffixHash: true
+      labels:
+        helm.toolkit.fluxcd.io/watch: "true"


### PR DESCRIPTION
## What

Make Flux actually watch the externalized `valuesFrom: ConfigMap` HelmRelease pattern, so editing a `values.yaml` (which regenerates the values ConfigMap) reliably triggers a HelmRelease redeploy.

Applied to **all 18 active HelmReleases** (monitoring + infra + apps):

1. **Workaround 1 — watch label**: add `helm.toolkit.fluxcd.io/watch: "true"` to each values ConfigMap generator in the overlay `kustomization.yaml`. helm-controller's default config-watch selector matches this label and reconciles the HelmRelease immediately on a value change. (This is the mechanism Flux provides for exactly this use case.)
2. **Workaround 3 — short interval**: drop `spec.interval` from `1h` → `1m`, so drift is also caught by periodic reconciliation as a fallback.

`external-secrets` is **excluded**: it lists `valuesFrom: ConfigMap` but the reference is commented out (not active).

## How to Test

1. After merge, Flux applies the labels + intervals.
2. Edit any app's `overlays/default/values.yaml` (e.g. Grafana), commit, merge — the corresponding HelmRelease should reconcile **within ~1 min** (event-driven via label watch) and upgrade without running `flux reconcile hr`.
3. Confirm with `kubectl get hr <name> -n <ns>` revision bumps and `kubectl get cm <name>-values -n <ns> --show-labels` shows `helm.toolkit.fluxcd.io/watch=true`.

## Impact

- No chart/binary changes; only labels + reconcile interval.
- Shorter interval (1m) means helm-controller does more frequent drift scans for these releases — negligible load for a homelab of this size.
- Validated: all 18 overlays build with `kubectl kustomize`; label renders on generated values ConfigMaps.

Note: `helm-controller` here runs at v1.5.3 with the default config-watch label selector, which is why the label (not a cluster-wide flag) is the chosen mechanism.