### PR TITLE
chore(hermes-agent): add fluxcd, kustomize, and uv CLI tools

### DIFF
--- a/nixos/modules/hermes-agent.nix
+++ b/nixos/modules/hermes-agent.nix
@@ -99,6 +99,6 @@ in
     };
 
     # Common tools available to the agent's terminal backend.
-    extraPackages = with pkgs; [ git jq ripgrep ffmpeg nodejs kubectl kubernetes-helm ];
+    extraPackages = with pkgs; [ git jq ripgrep ffmpeg nodejs kubectl kubernetes-helm fluxcd kustomize uv ];
   };
 }


### PR DESCRIPTION
## What

Added three CLI tools — `fluxcd`, `kustomize`, and `uv` — to the Hermes agent machine's `extraPackages`. These are provisioned into the agent's terminal backend environment, matching the existing `kubectl` and `kubernetes-helm` entries already present.

- source: `nixos/modules/hermes-agent.nix`

## How to Test

1. Build the host config:
   ```sh
   nixos-rebuild build --flake .#hermes-agent --no-link
   ```
2. Confirm the tool binaries (`fluxcd-2.9.3`, `kustomize-5.8.1`, `uv-0.12.1`) are present in the built closure.
3. On the machine, from the agent's environment: `flux --version`, `kustomize version`, `uv --version`.

## Impact

- Adds three packages to the Hermes agent's runtime environment only; no impact to other hosts or system-wide PATH.
- Low risk; no services or networking touched.