### PR TITLE
feat(pihole): add local DNS rewrite for homelab.leehosanganson.dev

### DIFF
--- a/nixos/modules/pihole.nix
+++ b/nixos/modules/pihole.nix
@@ -68,9 +68,7 @@ in
           ];
         };
         # Local DNS rewrite: resolve the homelab domain and all its subdomains
-        # to the HAProxy ingress VIP. dnsmasq_lines is injected into FTL's
-        # generated dnsmasq config — no /etc/dnsmasq.d drop-in required
-        # (equivalent to misc.etc_dnsmasq_d + address= entry, but declarative).
+        # to the HAProxy
         misc.dnsmasq_lines = [
           "address=/homelab.leehosanganson.dev/192.168.1.250"
         ];

--- a/nixos/modules/pihole.nix
+++ b/nixos/modules/pihole.nix
@@ -67,6 +67,13 @@ in
             "192.168.1.194 pve04.home.lab"
           ];
         };
+        # Local DNS rewrite: resolve the homelab domain and all its subdomains
+        # to the HAProxy ingress VIP. dnsmasq_lines is injected into FTL's
+        # generated dnsmasq config — no /etc/dnsmasq.d drop-in required
+        # (equivalent to misc.etc_dnsmasq_d + address= entry, but declarative).
+        misc.dnsmasq_lines = [
+          "address=/homelab.leehosanganson.dev/192.168.1.250"
+        ];
         webserver.api.cli_pw = true; # required so `lists` load on boot
       };
 


### PR DESCRIPTION
## What

- Adds a local DNS rewrite to the shared pihole module (`nixos/modules/pihole.nix`): `homelab.leehosanganson.dev` and all its subdomains now resolve to the HAProxy ingress VIP `192.168.1.250`.
- Uses `services.pihole-ftl.settings.misc.dnsmasq_lines`, which injects the dnsmasq `address=` line into FTL's generated dnsmasq config via `pihole.toml`.
- This replaces the manual change previously applied on the hosts (`/etc/dnsmasq.d/01-sshpihole.conf` + enabling `misc.etc_dnsmasq_d` in the web UI) with a fully declarative equivalent — no `/etc/dnsmasq.d` drop-in required.

## How to Test

1. `cd nixos && nix eval .#nixosConfigurations.pihole-1.config.services.pihole-ftl.settings.misc.dnsmasq_lines` (and `pihole-2`) — both evaluate; verified locally.
2. Deploy, then `dig @192.168.1.132 grafana.homelab.leehosanganson.dev` and `dig @192.168.1.133 homelab.leehosanganson.dev` — both should return `192.168.1.250`.
3. Confirm existing `*.home.lab` local records and ad-blocking still work, e.g. `dig @192.168.1.132 nas1.home.lab` → `192.168.1.197`.

## Impact

- Applies to both pihole-1 and pihole-2 (shared module) — keeps the two resolvers identical.
- dnsmasq `address=/domain/ip` semantics: wildcard over the domain itself and all subdomains, matching every `*.homelab.leehosanganson.dev` ingress host.
- Low risk, additive only. `misc.readOnly = true` remains set, so the UI can no longer drift from this declared config.