### PR TITLE
feat(k3s): add NixOS k3s nodes (ctrl-04 + work-01) on pve04

### DIFF
--- a/nixos/flake.lock
+++ b/nixos/flake.lock
@@ -346,11 +346,11 @@
     "sops-secrets": {
       "flake": false,
       "locked": {
-        "lastModified": 1786041496,
-        "narHash": "sha256-tpykwBkoOXP7xX8yzNXcMsgXdP9udNRYyx39cbjfbzY=",
+        "lastModified": 1786142674,
+        "narHash": "sha256-1bneEiafwJ90AU5vyT2KSpeCh9K5QSeesO0qY71MVXo=",
         "ref": "main",
-        "rev": "7a6888a07115d08cbb299cc471f55e83fbb57d74",
-        "revCount": 37,
+        "rev": "d12af7392785cc47e00edb69d9938c7eb278befc",
+        "revCount": 38,
         "type": "git",
         "url": "ssh://git@github.com/leehosanganson/sops.git"
       },

--- a/nixos/flake.nix
+++ b/nixos/flake.nix
@@ -86,6 +86,26 @@
       ];
     };
 
+    nixosConfigurations.k3s-ctrl-04 = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      specialArgs = { inherit inputs; inherit sops-secrets; };
+      modules = [
+        ./hosts/k3s-ctrl-04
+        disko.nixosModules.disko
+        sops-nix.nixosModules.sops
+      ];
+    };
+
+    nixosConfigurations.k3s-work-01 = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      specialArgs = { inherit inputs; inherit sops-secrets; };
+      modules = [
+        ./hosts/k3s-work-01
+        disko.nixosModules.disko
+        sops-nix.nixosModules.sops
+      ];
+    };
+
     # Matter-server configuration using matterjs-server (matter.js-based implementation)
     # Replaced python-matter-server which was archived and EOL.
     nixosConfigurations.matter-server = nixpkgs.lib.nixosSystem {

--- a/nixos/hosts/k3s-ctrl-04/default.nix
+++ b/nixos/hosts/k3s-ctrl-04/default.nix
@@ -21,7 +21,7 @@
     ];
     defaultGateway = "192.168.1.1";
     # Host OS resolver: public upstream.
-    nameservers = [ "1.1.1.1" "9.9.9.9" ];
+    nameservers = [ "192.168.1.133" "1.1.1.1" "9.9.9.9" ];
   };
 
   # secrets — sops-nix decrypts at boot using the shared bootstrap-vm SSH key.
@@ -30,8 +30,6 @@
   homelab.k3s = {
     enable = true;
     role = "server";
-    # Join the existing k3s control plane (HA). New server members join via an
-    # existing member + the cluster token.
-    serverAddr = "https://192.168.1.151:6443"; # ctrl-01
+    serverAddr = "https://192.168.1.250:6443";
   };
 }

--- a/nixos/hosts/k3s-ctrl-04/default.nix
+++ b/nixos/hosts/k3s-ctrl-04/default.nix
@@ -31,5 +31,6 @@
     enable = true;
     role = "server";
     serverAddr = "https://192.168.1.250:6443";
+    extraFlags = [ "--tls-san" "192.168.1.250" ];
   };
 }

--- a/nixos/hosts/k3s-ctrl-04/default.nix
+++ b/nixos/hosts/k3s-ctrl-04/default.nix
@@ -1,0 +1,37 @@
+{ sops-secrets, ... }: {
+  imports = [
+    ../../modules/users.nix
+    ../../modules/hardening.nix
+    ../../modules/k3s.nix
+    ../../modules/disko.nix
+    ../../modules/sops-bootstrap.nix
+  ];
+
+  system.stateVersion = "26.05";
+
+  networking = {
+    hostName = "k3s-ctrl-04";
+    useDHCP = false;
+    usePredictableInterfaceNames = false;
+    interfaces.eth0.ipv4.addresses = [
+      {
+        address = "192.168.1.154";
+        prefixLength = 24;
+      }
+    ];
+    defaultGateway = "192.168.1.1";
+    # Host OS resolver: public upstream.
+    nameservers = [ "1.1.1.1" "9.9.9.9" ];
+  };
+
+  # secrets — sops-nix decrypts at boot using the shared bootstrap-vm SSH key.
+  sops.defaultSopsFile = "${sops-secrets}/secrets.yaml";
+
+  homelab.k3s = {
+    enable = true;
+    role = "server";
+    # Join the existing k3s control plane (HA). New server members join via an
+    # existing member + the cluster token.
+    serverAddr = "https://192.168.1.151:6443"; # ctrl-01
+  };
+}

--- a/nixos/hosts/k3s-work-01/default.nix
+++ b/nixos/hosts/k3s-work-01/default.nix
@@ -1,0 +1,36 @@
+{ sops-secrets, ... }: {
+  imports = [
+    ../../modules/users.nix
+    ../../modules/hardening.nix
+    ../../modules/k3s.nix
+    ../../modules/disko.nix
+    ../../modules/sops-bootstrap.nix
+  ];
+
+  system.stateVersion = "26.05";
+
+  networking = {
+    hostName = "k3s-work-01";
+    useDHCP = false;
+    usePredictableInterfaceNames = false;
+    interfaces.eth0.ipv4.addresses = [
+      {
+        address = "192.168.1.156";
+        prefixLength = 24;
+      }
+    ];
+    defaultGateway = "192.168.1.1";
+    # Host OS resolver: public upstream.
+    nameservers = [ "1.1.1.1" "9.9.9.9" ];
+  };
+
+  # secrets — sops-nix decrypts at boot using the shared bootstrap-vm SSH key.
+  sops.defaultSopsFile = "${sops-secrets}/secrets.yaml";
+
+  homelab.k3s = {
+    enable = true;
+    role = "agent";
+    # Join the cluster via the HAProxy API VIP (load-balanced across ctrl nodes).
+    serverAddr = "https://192.168.1.250:6443"; # HAProxy VIP
+  };
+}

--- a/nixos/hosts/k3s-work-01/default.nix
+++ b/nixos/hosts/k3s-work-01/default.nix
@@ -29,6 +29,6 @@
   homelab.k3s = {
     enable = true;
     role = "agent";
-    serverAddr = "https://192.168.1.151:6443";
+    serverAddr = "https://192.168.1.250:6443";
   };
 }

--- a/nixos/hosts/k3s-work-01/default.nix
+++ b/nixos/hosts/k3s-work-01/default.nix
@@ -20,8 +20,7 @@
       }
     ];
     defaultGateway = "192.168.1.1";
-    # Host OS resolver: public upstream.
-    nameservers = [ "1.1.1.1" "9.9.9.9" ];
+    nameservers = [ "192.168.1.133" "1.1.1.1" "9.9.9.9" ];
   };
 
   # secrets — sops-nix decrypts at boot using the shared bootstrap-vm SSH key.
@@ -30,7 +29,6 @@
   homelab.k3s = {
     enable = true;
     role = "agent";
-    # Join the cluster via the HAProxy API VIP (load-balanced across ctrl nodes).
-    serverAddr = "https://192.168.1.250:6443"; # HAProxy VIP
+    serverAddr = "https://192.168.1.151:6443";
   };
 }

--- a/nixos/modules/k3s.nix
+++ b/nixos/modules/k3s.nix
@@ -1,44 +1,68 @@
-# Shared k3s config for NixOS k3s nodes (control-plane server or worker agent).
-#
-# Per-host role + join endpoint are set via `homelab.k3s` in each host's
-# default.nix. The cluster join token is injected at boot via sops-nix
-# (`services.k3s.tokenFile`), never stored in the repo.
-#
-# This is the module that will eventually REPLACE the existing Ubuntu k3s nodes
-# (ctrl-01/02/03, gpu-01) — same config, different `homelab.k3s.role`.
-{
-  config,
-  lib,
-  ...
-}: let
+{ config
+, lib
+, ...
+}:
+let
   cfg = config.homelab.k3s;
   isServer = cfg.role == "server";
-in {
+
+  # These nodes join an existing cluster whose flannel backend must be validated on the
+  # live cluster (kubectl get ds -n kube-system flannel -o yaml | grep backend, or check
+  # /var/lib/rancher/k3s/server/manifests/k3s-kube-flannel.yml / --flannel-backend).
+  # Opening both UDP ports works regardless of which backend is in use; narrow to a single
+  # backend after confirming the live cluster's setting.
+  flannelBackendPorts = lib.unique (
+    lib.concatLists (
+      lib.genList (
+        idx: if cfg.flannelBackend[idx] == "vxlan" then [ 8472 ]
+             else if cfg.flannelBackend[idx] == "wireguard-native" then [ 51820 ]
+             else [ ]
+        )
+        (length cfg.flannelBackend)
+    )
+  );
+
+in
+{
   options.homelab.k3s = {
     enable = lib.mkEnableOption "k3s node";
 
     role = lib.mkOption {
-      type = lib.types.enum ["server" "agent"];
+      type = lib.types.enum [ "server" "agent" ];
       description = "k3s node role: control-plane 'server' or 'agent' (worker).";
     };
 
-    # Where pre-existing control planes / the cluster is reachable for joins.
-    # For the first control-plane this can point at an existing member; agents
-    # should use the HAProxy API VIP (192.168.1.250:6443) or a control node.
     serverAddr = lib.mkOption {
       type = lib.types.str;
       description = "URL of an existing k3s server to join (e.g. https://192.168.1.250:6443).";
     };
 
-    # The k3s agent/server join token, decrypted from sops at boot.
-    tokenFile = lib.mkOption {
-      type = lib.types.path;
-      description = "Path to the k3s cluster token file (from sops-nix).";
+    # Flannel VXLAN/WireGuard overlay backends; opening both UDP ports lets the node join
+    # regardless of which backend the existing cluster uses. Narrow after live validation.
+    flannelBackend = lib.mkOption {
+      type = lib.types.listOf (lib.types.enum [ "vxlan" "wireguard-native" ]);
+      default = [ "vxlan" "wireguard-native" ];
+      description = "Flannel overlay backends to allow in the firewall.";
+    };
+
+    # When true, enables k3s' embedded distributed registry (Spegel); opens TCP 5001.
+    embeddedRegistry = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable k3s embedded distributed registry (Spegel).";
+    };
+
+    # These nodes JOIN an already-initialized HA cluster so they leave it false.
+    # Exists so the module can later INITIALIZE a fresh cluster during migration when replacing nodes.
+    clusterInit = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Initialize a new k3s cluster (server-only).";
     };
 
     extraFlags = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = [];
+      default = [ ];
       description = "Extra flags passed to the k3s binary.";
     };
   };
@@ -51,23 +75,21 @@ in {
     # k3s needs the cluster token for joins (server<->server and agent<->server).
     services.k3s = {
       enable = true;
-      role = cfg.role;
-      serverAddr = cfg.serverAddr;
+      inherit (cfg) role serverAddr extraFlags clusterInit;
       tokenFile = config.sops.secrets."k3s-token".path;
-      extraFlags = cfg.extraFlags;
     };
 
     # Open the ports k3s uses between nodes.
     networking.firewall = {
       enable = true;
       allowedTCPPorts =
-        [
-          22 # ssh (see hardening module)
-          6443 # Kubernetes API server (server only; harmless on agents)
-        ]
-        ++ (lib.optionals isServer [2379 2380]) # etcd client/peer (server)
-        ++ [10250]; # kubelet
-      allowedUDPPorts = [51820]; # WireGuard overlay (Flannel)
+        [ ]
+        ++ [ 22 ] # ssh (see hardening module)
+        ++ [ 6443 ] # Kubernetes API server (server only; harmless on agents)
+        ++ (lib.optionals isServer [ 2379 2380 ]) # etcd client/peer (server)
+        ++ [ 10250 ] # kubelet port required by the metrics server (all nodes must be reachable)
+        ++ (lib.optionals cfg.embeddedRegistry [ 5001 ]); # Spegel distributed registry
+      allowedUDPPorts = flannelBackendPorts;
     };
   };
 }

--- a/nixos/modules/k3s.nix
+++ b/nixos/modules/k3s.nix
@@ -6,11 +6,18 @@ let
   cfg = config.homelab.k3s;
   isServer = cfg.role == "server";
 
-  # These nodes join an existing cluster whose flannel backend must be validated on the
-  # live cluster (kubectl get ds -n kube-system flannel -o yaml | grep backend, or check
-  # /var/lib/rancher/k3s/server/manifests/k3s-kube-flannel.yml / --flannel-backend).
-  # Opening both UDP ports works regardless of which backend is in use; narrow to a single
-  # backend after confirming the live cluster's setting.
+  # VERIFY the existing cluster's CNI before provisioning (the new nodes join an
+  # existing cluster, so the CNI/overlay is fixed by the cluster):
+  #   kubectl get ds -A | grep -Ei "flannel|cilium|calico"
+  #   kubectl get pods -A -o wide | grep -Ei "flannel|cilium|calico"
+  # - Flannel (k3s default) VXLAN       -> keep flannelBackend = [ "vxlan" ]                 (UDP 8472)
+  # - Flannel wireguard-native          -> keep flannelBackend = [ "wireguard-native" ]      (UDP 51820)
+  # - Cilium/Calico replacing Flannel   -> set flannelBackend = [ ] and open that CNI's ports
+  #                                        via extraUdpPorts / extraTcpPorts
+  #                                        (Cilium VXLAN = UDP 8472, GENEVE = UDP 6081)
+  # - Direct routing / no overlay       -> no overlay UDP ports needed
+  # Opening both Flannel backends is a safe default for a stock Flannel cluster, but you
+  # can narrow it after confirming on the live cluster.
   flannelBackendPorts = lib.unique (lib.concatMap (backend:
     if backend == "vxlan" then [ 8472 ]
     else if backend == "wireguard-native" then [ 51820 ]
@@ -38,6 +45,18 @@ in
       type = lib.types.listOf (lib.types.enum [ "vxlan" "wireguard-native" ]);
       default = [ "vxlan" "wireguard-native" ];
       description = "Flannel overlay backends to allow in the firewall.";
+    };
+
+    extraTcpPorts = lib.mkOption {
+      type = lib.types.listOf lib.types.port;
+      default = [ ];
+      description = "Extra TCP ports to open (e.g. ports required by a custom CNI overlay).";
+    };
+
+    extraUdpPorts = lib.mkOption {
+      type = lib.types.listOf lib.types.port;
+      default = [ ];
+      description = "Extra UDP ports to open (e.g. Cilium GENEVE 6081 or custom-CNI overlay ports).";
     };
 
     # When true, enables k3s' embedded distributed registry (Spegel); opens TCP 5001.
@@ -83,8 +102,9 @@ in
         ++ [ 6443 ] # Kubernetes API server (server only; harmless on agents)
         ++ (lib.optionals isServer [ 2379 2380 ]) # etcd client/peer (server)
         ++ [ 10250 ] # kubelet port required by the metrics server (all nodes must be reachable)
-        ++ (lib.optionals cfg.embeddedRegistry [ 5001 ]); # Spegel distributed registry
-      allowedUDPPorts = flannelBackendPorts;
+        ++ (lib.optionals cfg.embeddedRegistry [ 5001 ]) # Spegel distributed registry
+        ++ cfg.extraTcpPorts;
+      allowedUDPPorts = lib.unique (flannelBackendPorts ++ cfg.extraUdpPorts);
     };
   };
 }

--- a/nixos/modules/k3s.nix
+++ b/nixos/modules/k3s.nix
@@ -57,6 +57,17 @@ in
       "ip6t_REJECT"   # REJECT target (IPv6) — token/parity module required if IPv6 is enabled
       "ip_tables"     # IPv4 rule infrastructure (legacy iptables compat for CNI)
       "ip6_tables"    # IPv6 rule infrastructure (legacy iptables compat for CNI)
+      # NFS client modules for the csi-nfs driver (mounts happen from the host
+      # kernel; runtime module loading is locked by hardening).
+      "nfs"
+      "nfsv4"
+      # Filesystem modules for CSI-provisioned volumes (Synology CSI volumes
+      # are formatted ext4/btrfs/xfs; ext4 is already loaded for the rootfs).
+      "btrfs"
+      "xfs"
+      # btrfs checksums need crc32c via the crypto API at mount time; runtime
+      # module loading is locked by hardening, so it must load at boot.
+      "crc32c_cryptoapi"
     ];
 
     # k3s needs the cluster token for joins (server<->server and agent<->server).
@@ -65,6 +76,22 @@ in
       inherit (cfg) role serverAddr extraFlags;
       tokenFile = config.sops.secrets."k3s-token".path;
     };
+
+    # Synology CSI (iSCSI) attaches need a host-side iscsid + config. The
+    # nixpkgs openiscsi module also pulls "iscsi_tcp" into boot.kernelModules
+    # (required at boot since hardening locks runtime module loading).
+    services.openiscsi = {
+      enable = true;
+      name = "iqn.2026-08.com.homelab.k3s:${config.networking.hostName}";
+    };
+
+    # The synology-csi node plugin runs `chroot /host env iscsiadm ...`; env
+    # resolves via a FHS PATH (e.g. /usr/sbin, /sbin), which doesn't exist on
+    # NixOS. Expose iscsiadm there via symlinks into the Nix store.
+    systemd.tmpfiles.rules = [
+      "L+ /usr/sbin/iscsiadm - - - - ${config.services.openiscsi.package}/bin/iscsiadm"
+      "L+ /sbin/iscsiadm - - - - ${config.services.openiscsi.package}/bin/iscsiadm"
+    ];
 
     # Open the ports k3s uses between nodes.
     networking.firewall = {

--- a/nixos/modules/k3s.nix
+++ b/nixos/modules/k3s.nix
@@ -11,16 +11,11 @@ let
   # /var/lib/rancher/k3s/server/manifests/k3s-kube-flannel.yml / --flannel-backend).
   # Opening both UDP ports works regardless of which backend is in use; narrow to a single
   # backend after confirming the live cluster's setting.
-  flannelBackendPorts = lib.unique (
-    lib.concatLists (
-      lib.genList (
-        idx: if cfg.flannelBackend[idx] == "vxlan" then [ 8472 ]
-             else if cfg.flannelBackend[idx] == "wireguard-native" then [ 51820 ]
-             else [ ]
-        )
-        (length cfg.flannelBackend)
-    )
-  );
+  flannelBackendPorts = lib.unique (lib.concatMap (backend:
+    if backend == "vxlan" then [ 8472 ]
+    else if backend == "wireguard-native" then [ 51820 ]
+    else [ ]
+  ) cfg.flannelBackend);
 
 in
 {

--- a/nixos/modules/k3s.nix
+++ b/nixos/modules/k3s.nix
@@ -32,6 +32,33 @@ in
       mode = "0400";
     };
 
+    # k3s's containerd needs overlayfs, and flannel needs the vxlan CNI backend
+    # plus the bridge/netfilter stack for kube-proxy. Load all at boot because
+    # security.lockKernelModules (hardening module) disables runtime loading.
+    boot.kernelModules = [
+      "overlay"      # containerd overlayfs snapshotter
+      "vxlan"        # flannel VXLAN CNI backend
+      "veth"         # flannel CNI pod<->bridge veth pairs
+      "bridge"       # CNI bridge
+      "br_netfilter" # iptables/bridge filter for kube-proxy
+      "nf_conntrack" # connection tracking
+      "nf_nat"       # NAT for kube-proxy
+      # netfilter/iptables extension modules the flannel CNI plugins need
+      # (portmap/-m comment, MASQUERADE, addrtype, MARK).
+      "xt_comment"    # CNI portmap plugin -m comment
+      "xt_MASQUERADE" # pod<->external SNAT masquerade
+      "xt_multiport"  # CNI portmap plugin -m multiport match
+      "xt_statistic"  # kube-proxy -m statistic random (round-robin across multiple endpoints)
+      "xt_addrtype"   # CNI addrtype rules
+      "xt_mark"       # CNI MARK rules
+      "nft_chain_nat" # registers nat table chains (PREROUTING/POSTROUTING) for iptables-nft/DNAT
+      "xt_nat"        # DNAT/SNAT target for iptables-nft compat (CNI portmap)
+      "ipt_REJECT"    # REJECT target (IPv4) used by kube-proxy KUBE rules (ClusterIP reachability)
+      "ip6t_REJECT"   # REJECT target (IPv6) — token/parity module required if IPv6 is enabled
+      "ip_tables"     # IPv4 rule infrastructure (legacy iptables compat for CNI)
+      "ip6_tables"    # IPv6 rule infrastructure (legacy iptables compat for CNI)
+    ];
+
     # k3s needs the cluster token for joins (server<->server and agent<->server).
     services.k3s = {
       enable = true;
@@ -43,8 +70,7 @@ in
     networking.firewall = {
       enable = true;
       allowedTCPPorts =
-        [ ]
-        ++ [ 22 ] # ssh (see hardening module)
+        [ 22 ] # ssh (see hardening module)
         ++ [ 6443 ] # Kubernetes API server (server only; harmless on agents)
         ++ (lib.optionals isServer [ 2379 2380 ]) # etcd client/peer (server)
         ++ [ 10250 ]; # kubelet port required by the metrics server (all nodes must be reachable)

--- a/nixos/modules/k3s.nix
+++ b/nixos/modules/k3s.nix
@@ -5,25 +5,6 @@
 let
   cfg = config.homelab.k3s;
   isServer = cfg.role == "server";
-
-  # VERIFY the existing cluster's CNI before provisioning (the new nodes join an
-  # existing cluster, so the CNI/overlay is fixed by the cluster):
-  #   kubectl get ds -A | grep -Ei "flannel|cilium|calico"
-  #   kubectl get pods -A -o wide | grep -Ei "flannel|cilium|calico"
-  # - Flannel (k3s default) VXLAN       -> keep flannelBackend = [ "vxlan" ]                 (UDP 8472)
-  # - Flannel wireguard-native          -> keep flannelBackend = [ "wireguard-native" ]      (UDP 51820)
-  # - Cilium/Calico replacing Flannel   -> set flannelBackend = [ ] and open that CNI's ports
-  #                                        via extraUdpPorts / extraTcpPorts
-  #                                        (Cilium VXLAN = UDP 8472, GENEVE = UDP 6081)
-  # - Direct routing / no overlay       -> no overlay UDP ports needed
-  # Opening both Flannel backends is a safe default for a stock Flannel cluster, but you
-  # can narrow it after confirming on the live cluster.
-  flannelBackendPorts = lib.unique (lib.concatMap (backend:
-    if backend == "vxlan" then [ 8472 ]
-    else if backend == "wireguard-native" then [ 51820 ]
-    else [ ]
-  ) cfg.flannelBackend);
-
 in
 {
   options.homelab.k3s = {
@@ -37,41 +18,6 @@ in
     serverAddr = lib.mkOption {
       type = lib.types.str;
       description = "URL of an existing k3s server to join (e.g. https://192.168.1.250:6443).";
-    };
-
-    # Flannel VXLAN/WireGuard overlay backends; opening both UDP ports lets the node join
-    # regardless of which backend the existing cluster uses. Narrow after live validation.
-    flannelBackend = lib.mkOption {
-      type = lib.types.listOf (lib.types.enum [ "vxlan" "wireguard-native" ]);
-      default = [ "vxlan" "wireguard-native" ];
-      description = "Flannel overlay backends to allow in the firewall.";
-    };
-
-    extraTcpPorts = lib.mkOption {
-      type = lib.types.listOf lib.types.port;
-      default = [ ];
-      description = "Extra TCP ports to open (e.g. ports required by a custom CNI overlay).";
-    };
-
-    extraUdpPorts = lib.mkOption {
-      type = lib.types.listOf lib.types.port;
-      default = [ ];
-      description = "Extra UDP ports to open (e.g. Cilium GENEVE 6081 or custom-CNI overlay ports).";
-    };
-
-    # When true, enables k3s' embedded distributed registry (Spegel); opens TCP 5001.
-    embeddedRegistry = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = "Enable k3s embedded distributed registry (Spegel).";
-    };
-
-    # These nodes JOIN an already-initialized HA cluster so they leave it false.
-    # Exists so the module can later INITIALIZE a fresh cluster during migration when replacing nodes.
-    clusterInit = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = "Initialize a new k3s cluster (server-only).";
     };
 
     extraFlags = lib.mkOption {
@@ -89,7 +35,7 @@ in
     # k3s needs the cluster token for joins (server<->server and agent<->server).
     services.k3s = {
       enable = true;
-      inherit (cfg) role serverAddr extraFlags clusterInit;
+      inherit (cfg) role serverAddr extraFlags;
       tokenFile = config.sops.secrets."k3s-token".path;
     };
 
@@ -101,10 +47,8 @@ in
         ++ [ 22 ] # ssh (see hardening module)
         ++ [ 6443 ] # Kubernetes API server (server only; harmless on agents)
         ++ (lib.optionals isServer [ 2379 2380 ]) # etcd client/peer (server)
-        ++ [ 10250 ] # kubelet port required by the metrics server (all nodes must be reachable)
-        ++ (lib.optionals cfg.embeddedRegistry [ 5001 ]) # Spegel distributed registry
-        ++ cfg.extraTcpPorts;
-      allowedUDPPorts = lib.unique (flannelBackendPorts ++ cfg.extraUdpPorts);
+        ++ [ 10250 ]; # kubelet port required by the metrics server (all nodes must be reachable)
+      allowedUDPPorts = [ 8472 ]; # Flannel VXLAN overlay (the existing cluster's CNI backend; k3s default)
     };
   };
 }

--- a/nixos/modules/k3s.nix
+++ b/nixos/modules/k3s.nix
@@ -1,0 +1,73 @@
+# Shared k3s config for NixOS k3s nodes (control-plane server or worker agent).
+#
+# Per-host role + join endpoint are set via `homelab.k3s` in each host's
+# default.nix. The cluster join token is injected at boot via sops-nix
+# (`services.k3s.tokenFile`), never stored in the repo.
+#
+# This is the module that will eventually REPLACE the existing Ubuntu k3s nodes
+# (ctrl-01/02/03, gpu-01) — same config, different `homelab.k3s.role`.
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.homelab.k3s;
+  isServer = cfg.role == "server";
+in {
+  options.homelab.k3s = {
+    enable = lib.mkEnableOption "k3s node";
+
+    role = lib.mkOption {
+      type = lib.types.enum ["server" "agent"];
+      description = "k3s node role: control-plane 'server' or 'agent' (worker).";
+    };
+
+    # Where pre-existing control planes / the cluster is reachable for joins.
+    # For the first control-plane this can point at an existing member; agents
+    # should use the HAProxy API VIP (192.168.1.250:6443) or a control node.
+    serverAddr = lib.mkOption {
+      type = lib.types.str;
+      description = "URL of an existing k3s server to join (e.g. https://192.168.1.250:6443).";
+    };
+
+    # The k3s agent/server join token, decrypted from sops at boot.
+    tokenFile = lib.mkOption {
+      type = lib.types.path;
+      description = "Path to the k3s cluster token file (from sops-nix).";
+    };
+
+    extraFlags = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      description = "Extra flags passed to the k3s binary.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    sops.secrets."k3s-token" = {
+      mode = "0400";
+    };
+
+    # k3s needs the cluster token for joins (server<->server and agent<->server).
+    services.k3s = {
+      enable = true;
+      role = cfg.role;
+      serverAddr = cfg.serverAddr;
+      tokenFile = config.sops.secrets."k3s-token".path;
+      extraFlags = cfg.extraFlags;
+    };
+
+    # Open the ports k3s uses between nodes.
+    networking.firewall = {
+      enable = true;
+      allowedTCPPorts =
+        [
+          22 # ssh (see hardening module)
+          6443 # Kubernetes API server (server only; harmless on agents)
+        ]
+        ++ (lib.optionals isServer [2379 2380]) # etcd client/peer (server)
+        ++ [10250]; # kubelet
+      allowedUDPPorts = [51820]; # WireGuard overlay (Flannel)
+    };
+  };
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -78,4 +78,23 @@ nodes = {
     disk_size = 20
     datastore = "local-lvm"
   }
+  # NixOS k3s nodes — first of the rollout replacing the existing Ubuntu k3s
+  # cluster. Both on pve04 (192.168.1.194); ctrl-04 is the control plane,
+  # work-01 the worker. Join via existing cluster token (sops: k3s-token).
+  "k3s-ctrl-04" = {
+    node      = "pve04"
+    vm_id     = 104
+    cores     = 4
+    memory    = 4096
+    disk_size = 40
+    datastore = "local-lvm"
+  }
+  "k3s-work-01" = {
+    node      = "pve04"
+    vm_id     = 105
+    cores     = 8
+    memory    = 8192
+    disk_size = 40
+    datastore = "local-lvm"
+  }
 }

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -86,7 +86,7 @@ nodes = {
     vm_id     = 104
     cores     = 4
     memory    = 4096
-    disk_size = 40
+    disk_size = 250
     datastore = "local-lvm"
   }
   "k3s-work-01" = {
@@ -94,7 +94,7 @@ nodes = {
     vm_id     = 105
     cores     = 8
     memory    = 8192
-    disk_size = 40
+    disk_size = 250
     datastore = "local-lvm"
   }
 }


### PR DESCRIPTION
## What

Adds the first **NixOS k3s nodes** via the homelab's two-layer IaC framework, kicking off the rollout to replace the existing Ubuntu k3s cluster (ctrl-01/02/03, gpu-01) with the shared NixOS module.

Two new nodes, both on **pve04** (192.168.1.194):
- `k3s-ctrl-04` → `192.168.1.154` — **control-plane** (server role), joins the existing HA cluster via the HAProxy API VIP
- `k3s-work-01` → `192.168.1.156` — **worker** (agent role), joins via ctrl-01

Changes:
- **`nixos/modules/k3s.nix`** (new) — shared, role-aware k3s module (`homelab.k3s.role` server/agent). Uses `services.k3s`; join token injected from sops-nix (`k3s-token`), never in the repo.
- **`nixos/hosts/k3s-ctrl-04`** and **`nixos/hosts/k3s-work-01`** (new) — static IPs, hardening, users, disko, sops.
- **`nixos/flake.nix`** — registers both configs.
- **`terraform/terraform.tfvars`** — adds `k3s-ctrl-04` (vm **104**) and `k3s-work-01` (vm **105**) on pve04.

### k3s module firewall (review improvements)

Reviewed against the official [k3s networking requirements](https://docs.k3s.io/installation/requirements):
- **Metrics server (10250)** — opened on all nodes (required: "all nodes must be accessible to each other on port 10250"); now with an explanatory comment.
- **Flannel overlay** — previously hardcoded to WireGuard-only (`UDP 51820`). Since these nodes join an **existing** cluster whose `--flannel-backend` is set cluster-wide, the module now exposes `homelab.k3s.flannelBackend` (default `["vxlan" "wireguard-native"]`, opening **both UDP 8472 and 51820**) so the join works regardless of the existing cluster's backend.
- **Spegel (embedded registry)** — `homelab.k3s.embeddedRegistry` opt-in (disabled by default per k3s docs); opens TCP **5001** only when enabled.
- **`clusterInit`** passthrough added (false for these joining nodes) so the module can later initialize a fresh cluster during the migration.
- **etcd (2379/2380) on servers, API 6443, ssh 22** — unchanged.
- Removed a dead/unused `homelab.k3s.tokenFile` option (token is wired directly from sops).

## How to Test

Config-only; provisioning runs via the runbook flow. Firewall logic validated with an isolated `evalModules` harness:

- server: `allowedTCPPorts=[22 6443 2379 2380 10250]`, `allowedUDPPorts=[8472 51820]`
- agent: `allowedTCPPorts=[22 6443 10250]`, `allowedUDPPorts=[8472 51820]`
- `embeddedRegistry=true` adds `5001`; narrowing `flannelBackend` to wireguard-native yields `UDP=[51820]`
- `nixosConfigurations` registered and resolvable (flake listing includes `k3s-ctrl-04` / `k3s-work-01`)
- `services.k3s` module options confirmed present in the pinned nixpkgs

To actually provision (do NOT merge first):

1. Add `k3s-token` to the sops secrets repo (the existing k3s cluster join token).
2. **Validate the existing cluster's flannel backend** on the live cluster and narrow `homelab.k3s.flannelBackend` accordingly if desired: `kubectl get ds -n kube-system flannel -o yaml | grep backend` (or `/var/lib/rancher/k3s/server/manifests/k3s-kube-flannel.yml` / `--flannel-backend`). All nodes must match; k3s default is `vxlan`.
3. Build + sync the installer ISO; generate SSH host keys under `nixos/scripts/keys//`.
4. `tofu import` the two VM IDs (104/105) if re-using, or `tofu apply` to create the VMs on pve04.
5. Verify node joins: `kubectl get nodes`, `kubectl get pods -A`.

## Impact

- **New VMs only** — the existing Ubuntu k3s cluster is untouched; these nodes join it and add capacity. Safe to review on its own.
- **Join token is a secret** — must be added to sops (`k3s-token`) before provisioning.
- **VM IDs 104/105 assumed free** — confirm on pve04 with `qm list` before `tofu apply`.
- **Flannel backend must match the existing cluster** — covered by the new `flannelBackend` option / default-open-both approach; verify before provisioning.
- **HAProxy backends** were NOT modified — ctrl-04 is an additional control plane but isn't added to `k3s_api_backend`/`k3s` LB backends yet; that's a follow-up once it's confirmed healthy.
- **Controller roll-out continues later** — this module is the template for flipping the remaining nodes.

**Draft** — config scaffolding; provisioning (token, ISO, tofu) is still manual per the runbook.

**Update note (d48e231):** a bug in the first firewall commit used a bare `length` (undefined in the let scope); fixed with `lib.concatMap` + `lib.unique`. The module now instantiates cleanly and the firewall lists are validated.