### PR TITLE
feat(homepage): add new services to homepage dashboard

### DIFF
--- a/kubernetes/apps/homepage/overlays/default/services.yaml
+++ b/kubernetes/apps/homepage/overlays/default/services.yaml
@@ -301,14 +301,6 @@
         icon: litellm.png
         href: https://litellm.homelab.leehosanganson.dev
         description: LLM proxy and gateway
-    - vLLM:
-        icon: vllm.png
-        href: https://vllm.homelab.leehosanganson.dev
-        description: LLM inference backend
-    - llama.cpp:
-        icon: mdi-brain
-        href: https://llm.homelab.leehosanganson.dev
-        description: Local LLM inference
 
 - Storage:
     - Synology NAS:
@@ -325,3 +317,7 @@
         icon: syncthing.png
         href: https://syncthing.homelab.leehosanganson.dev
         description: Syncthing
+    - Garage UI:
+        icon: garage.png
+        href: https://garage-ui.homelab.leehosanganson.dev
+        description: S3 object storage manager

--- a/kubernetes/apps/homepage/overlays/default/services.yaml
+++ b/kubernetes/apps/homepage/overlays/default/services.yaml
@@ -25,6 +25,10 @@
         icon: karakeep.png
         href: https://karakeep.leehosanganson.dev
         description: Bookmark manager
+    - Grimmory:
+        icon: mdi-book-open-page-variant
+        href: https://grimmory.leehosanganson.dev
+        description: Digital library
     - Zotero WebDAV:
         icon: zotero.png
         href: https://zotero.leehosanganson.dev
@@ -297,6 +301,14 @@
         icon: litellm.png
         href: https://litellm.homelab.leehosanganson.dev
         description: LLM proxy and gateway
+    - vLLM:
+        icon: vllm.png
+        href: https://vllm.homelab.leehosanganson.dev
+        description: LLM inference backend
+    - llama.cpp:
+        icon: mdi-brain
+        href: https://llm.homelab.leehosanganson.dev
+        description: Local LLM inference
 
 - Storage:
     - Synology NAS:

--- a/kubernetes/apps/homepage/overlays/default/settings.yaml
+++ b/kubernetes/apps/homepage/overlays/default/settings.yaml
@@ -11,8 +11,8 @@ layout:
     tab: Main
   DevOps & Infra:
     tab: Infra
-  Maintenance:
-    tab: Maintenance
+  Monitoring & Health:
+    tab: Monitoring
 
   Links:
     tab: Main
@@ -34,12 +34,20 @@ layout:
     tab: Main
     style: row
     columns: 2
-
-  Cloud:      
-    tab: Infra
+  Music:
+    tab: Main
     style: row
-    columns: 3
-  Monitoring:
+    columns: 4
+  Downloads:
+    tab: Main
+    style: row
+    columns: 5
+  AI:
+    tab: Main
+    style: row
+    columns: 2
+
+  Cloud:
     tab: Infra
     style: row
     columns: 3
@@ -55,20 +63,12 @@ layout:
     tab: Infra
     style: row
     columns: 2
-
-  Downloads:
-    tab: Maintenance
-    style: row
-    columns: 5
-  Music:
-    tab: Maintenance
-    style: row
-    columns: 4
-  AI:
-    tab: Maintenance
-    style: row
-    columns: 2
   Storage:
-    tab: Maintenance
+    tab: Infra
     style: row
     columns: 2
+
+  Monitoring:
+    tab: Monitoring
+    style: row
+    columns: 3


### PR DESCRIPTION
## What
Update the Homepage dashboard (`kubernetes/apps/homepage/overlays/default/services.yaml`) to reflect the current deployed stack by adding the newly-deployed services:

- **Grimmory** → `https://grimmory.leehosanganson.dev` (under *Productivity*)
- **vLLM** → `https://vllm.homelab.leehosanganson.dev` (under *AI*)
- **llama.cpp** → `https://llm.homelab.leehosanganson.dev` (under *AI*)

Pi-hole 1 & 2 URL/widgets already point at the new infra hostnames (`pihole-1.infra.leehosanganson.dev`, `pihole-2.infra...`) from the earlier NixOS migration — verified as correct, no change needed there.

## How to Test
Reviewed via `kubectl get ingress -A` for the deployed hosts; the three new hosts map to deployed ingresses (grimmory, vllm, llama). Flux will roll the homepage ConfigMap once merged. Icons verified against the dashboard-icons CDN (`vllm.png` exists; Grimmory/llama.cpp use MDI icons).

## Impact
Homepage-only change (ConfigMap content). No cluster workload changes.