### PR TITLE
fix(chrome): pin deployment to GPU nodes via nodeSelector

### DIFF
--- a/kubernetes/apps/chrome/base/deployment.yaml
+++ b/kubernetes/apps/chrome/base/deployment.yaml
@@ -15,6 +15,8 @@ spec:
         app: chrome
     spec:
       runtimeClassName: nvidia
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
       containers:
         - name: chrome
           image: linuxserver/chrome:151.0.7922@sha256:9c90abd6458bf149152571aed65a8988916a1cdceb72d3690ba5e293bc16df9a

--- a/kubernetes/apps/llama.cpp/base/deployment.yaml
+++ b/kubernetes/apps/llama.cpp/base/deployment.yaml
@@ -15,6 +15,8 @@ spec:
         name: llama-cpp
     spec:
       runtimeClassName: nvidia
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
       initContainers:
         - name: download-model
           image: python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6

--- a/kubernetes/apps/vllm/base/deployment.yaml
+++ b/kubernetes/apps/vllm/base/deployment.yaml
@@ -15,6 +15,8 @@ spec:
         app: llm-backend
     spec:
       runtimeClassName: nvidia
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
       volumes:
         - name: vllm-config-volume
           configMap:


### PR DESCRIPTION
## What

The GPU-bound `chrome`, `vllm`, and `llama.cpp` Deployments only set `runtimeClassName: nvidia` to target the GPU node, but the GPU-operator-created `nvidia` RuntimeClass contains **no `scheduling.nodeSelector`** — `runtimeClassName` only selects the container runtime handler and does **not** constrain scheduling. With no `nodeSelector`, affinity, or (in some cases) toleration, the scheduler could place these workloads on a non-GPU node where they cannot start (missing `/dev/dri`, PVC attach/mount failures, no GPU resource).

This PR adds a `nodeSelector` to each of the three Deployments, pinning them to nodes that have a GPU present:

```yaml
nodeSelector:
  nvidia.com/gpu.present: "true"
```

`nvidia.com/gpu.present=true` is set by the NVIDIA GPU operator's gpu-feature-discovery on the GPU node (`k3s-gpu-01`), where `/dev/dri` (the hostPath `chrome` mounts) exists and GPUs are available.

Files changed:
- `kubernetes/apps/chrome/base/deployment.yaml`
- `kubernetes/apps/vllm/base/deployment.yaml`
- `kubernetes/apps/llama.cpp/base/deployment.yaml`

## How to Test

1. For each app, `kustomize build kubernetes/apps/<app>/overlays/default` — confirm `nodeSelector: nvidia.com/gpu.present: "true"` is present.
2. `kustomize build ... | kubectl apply --dry-run=server -f -` — validates against the cluster (read-only).
3. After Flux reconciles, verify pods land on the GPU node:
   `kubectl get pods -n <ns> -o wide` → expect `NODE: k3s-gpu-01`.

**Reproduction (before fix, chrome):** deleting the chrome pod saw the replacement scheduled to `k3s-work-01` (non-GPU) and stuck in `ContainerCreating` with `Volume not found` / missing `/dev/dri`.

## Impact

- Confined to the three app manifests (2 lines each).
- `chrome` / `llama.cpp` use `Recreate`; `vllm` uses rolling updates. All will roll onto the GPU node once reconciled.
- `vllm` keeps its existing `gpu=true:NoSchedule` toleration (harmless, and unused since no node tainted); `nodeSelector` now does the actual pinning.
