### PR TITLE
fix(metrics-server): add --kubelet-insecure-tls for k3s

### DIFF
--- a/kubernetes/infra/metrics-server/overlays/default/values.yaml
+++ b/kubernetes/infra/metrics-server/overlays/default/values.yaml
@@ -1,6 +1,7 @@
 args:
   - --kubelet-preferred-address-types=InternalIP
   - --metric-resolution=15s
+  - --kubelet-insecure-tls=true
 apiService:
   insecureSkipTLSVerify: false
 extraArgs:


### PR DESCRIPTION
## What

Fixes k9s showing N/A for CPU/mem because the metrics API (`metrics.k8s.io`) is down. Root cause: the Flux-managed metrics-server cannot scrape k3s kubelets because k3s kubelet serving certs are self-signed.

- Adds `--kubelet-insecure-tls=true` to the metrics-server `args:` so it can complete the TLS handshake to the kubelet on :10250.
- The `metrics-server` HelmRelease is the sole owner of the metrics API (k3s built-in metrics-server was already disabled in #547); this is the final remaining blocker before `kubectl top` works.

## How to Test

1. Let Flux reconcile the updated HelmRelease (or wait for the 1m interval).
2. Check the metrics-server pod restarted and the readiness probe `metric-storage-ready` reports ready.
3. Run `kubectl top nodes` and `kubectl top pods` — metrics should now be returned instead of "Metrics API not available".
4. Confirm `kubectl get apiservice v1beta1.metrics.k8s.io` is `Available=True`.
5. In k9s, verify CPU/mem columns are populated instead of N/A.

## Impact

- Scope is limited to a single `args:` entry in `overlays/default/values.yaml`; no other settings (e.g. `apiService.insecureSkipTLSVerify`, which governs the cert-manager serving cert for the APIService, not kubelet scraping) were touched.
- The change is declarative (Flux reconciliation); no cluster-side manual action is required.
- No server-node `nixos-rebuild` is required — PR #547 already disabled the k3s built-in metrics-server alongside this.
- Reviewers should confirm the metrics API becomes Available and that `kubectl top` returns real data after reconcile.
