### PR TITLE
fix(k3s): fix storage mounts and synology-csi on nixos nodes

### DIFF
--- a/nixos/modules/k3s.nix
+++ b/nixos/modules/k3s.nix
@@ -1,10 +1,33 @@
 { config
 , lib
+, pkgs
 , ...
 }:
 let
   cfg = config.homelab.k3s;
   isServer = cfg.role == "server";
+
+  # Wrapper for the Synology CSI node plugin's `chroot /host env iscsiadm ...`
+  # invocations. synology-csi v1.2.1's parseSessions() does an unguarded
+  # `strings.Split(e[3], ":")[1]` on each line of `iscsiadm -m session` output,
+  # which panics with "index out of range [1] with length 1" whenever a line's
+  # 4th whitespace field (the IQN position) contains no colon. On NixOS with
+  # open-iscsi 2.1.12 a session can be caught mid-teardown (no IQN yet), so the
+  # node plugin crash-loops, which also leaves the node without a stable volume
+  # dataset (NodeStageVolume then fails with "Volume[..] is not found"). Filtering
+  # `-m session` output to well-formed lines (4th field has a colon => an IQN)
+  # prevents the panic while preserving every legitimate session line.
+  iscsiadmWrapper = pkgs.writeShellScriptBin "iscsiadm" ''
+    real="${config.services.openiscsi.package}/bin/iscsiadm"
+    gawk="${pkgs.gawk}/bin/awk"
+    if [ "''${1:-}" = "-m" ] && [ "''${2:-}" = "session" ]; then
+      # CombinedOutput() merges stderr; normalise like the driver does and drop
+      # any line the parser would choke on, while preserving the real exit code.
+      "$real" "$@" 2>&1 | "$gawk" 'NF < 4 || $4 ~ /:/'
+      exit "''${PIPESTATUS[0]}"
+    fi
+    exec "$real" "$@"
+  '';
 in
 {
   options.homelab.k3s = {
@@ -90,12 +113,31 @@ in
       name = "iqn.2026-08.com.homelab.k3s:${config.networking.hostName}";
     };
 
+    # In-tree NFS PVs (spec.nfs, e.g. media-pv / qbit-download) are mounted by
+    # kubelet on the host, which needs the userspace NFS mount helper + client
+    # daemons (idmapd/statd) for NFSv4. Without them, kubelet's mount fails with
+    # "fsconfig() failed: NFS: mount program didn't pass remote address." (exit 32).
+    # In this nixpkgs snapshot, NFS *client* support is enabled by declaring nfs /
+    # nfs4 as supported filesystems: the tasks/filesystems/nfs module then adds
+    # nfs-utils to system.fsPackages and starts rpcbind/idmapd/statd. (The older
+    # services.nfs.client option no longer exists here.) kubelet already reaches
+    # mount(8) (the failure is at the helper stage), and mount(8) resolves
+    # type-specific helpers from /sbin and /usr/sbin even when those are absent
+    # from its PATH, so the tmpfiles rules below place mount.nfs in those FHS
+    # paths to make in-tree NFS mounts succeed.
+    boot.supportedFilesystems = [ "nfs" "nfs4" ];
+
     # The synology-csi node plugin runs `chroot /host env iscsiadm ...`; env
     # resolves via a FHS PATH (e.g. /usr/sbin, /sbin), which doesn't exist on
-    # NixOS. Expose iscsiadm there via symlinks into the Nix store.
+    # NixOS. Expose the wrapped iscsiadm there via symlinks into the Nix store.
+    # mount.nfs is exposed the same way for kubelet's in-tree NFS mounts.
     systemd.tmpfiles.rules = [
-      "L+ /usr/sbin/iscsiadm - - - - ${config.services.openiscsi.package}/bin/iscsiadm"
-      "L+ /sbin/iscsiadm - - - - ${config.services.openiscsi.package}/bin/iscsiadm"
+      "L+ /usr/sbin/iscsiadm - - - - ${iscsiadmWrapper}/bin/iscsiadm"
+      "L+ /sbin/iscsiadm - - - - ${iscsiadmWrapper}/bin/iscsiadm"
+      "L+ /sbin/mount.nfs - - - - ${pkgs.nfs-utils}/bin/mount.nfs"
+      "L+ /sbin/mount.nfs4 - - - - ${pkgs.nfs-utils}/bin/mount.nfs"
+      "L+ /usr/sbin/mount.nfs - - - - ${pkgs.nfs-utils}/bin/mount.nfs"
+      "L+ /usr/sbin/mount.nfs4 - - - - ${pkgs.nfs-utils}/bin/mount.nfs"
     ];
 
     # Open the ports k3s uses between nodes.


### PR DESCRIPTION
## What

Fixes redeployment of workloads drained from `k3s-ctrl-01` and re-scheduled onto the new NixOS nodes `k3s-work-01` (and `k3s-ctrl-04`). Those pods (jellyfin, qbittorrent, syncthing, termix, grafana, coder-db-4, life-in-the-uk-quiz-db-3) were stuck in ContainerCreating due to **two NixOS-specific storage problems**:

1. **In-tree NFS PVs fail to mount** (`media-pv`, `qbit-download`, `syncthing-data-pv`): kubelet mounts `spec.nfs` volumes on the host and needs the userspace `mount.nfs` helper + NFSv4 client daemons. NixOS lacks them, so mounts fail with `fsconfig() failed: NFS: mount program didn't pass remote address` (exit 32).
   - Adds `boot.supportedFilesystems = [ "nfs" "nfs4" ]` (the current nixpkgs mechanism that adds `nfs-utils` to `system.fsPackages` and starts `rpcbind`/`idmapd`/`statd`; the old `services.nfs.client` option no longer exists).
   - Symlinks `mount.nfs`/`mount.nfs4` into `/sbin` and `/usr/sbin` via tmpfiles so kubelet's `mount(8)` can resolve the helper.

2. **synology-csi node plugin crash-loops on NixOS nodes**: `parseSessions()` in synology-csi v1.2.1 does an unguarded `strings.Split(e[3], ":")[1]` on each line of `iscsiadm -m session`, panicking (`index out of range [1] with length 1`) when a line's 4th field has no colon (a session caught mid-teardown by open-iscsi 2.1.12). The crash leaves the node without a stable volume dataset, so `NodeStageVolume` then fails with `Volume[..] is not found`. Ubuntu nodes (open-iscsi 2.1.4) don't trigger it.
   - Wraps the host `iscsiadm` to filter `-m session` output to well-formed lines (4th field contains a colon), preserving the real exit code. Exposed to the CSI node plugin via the existing `/sbin` + `/usr/sbin` tmpfiles symlinks.

## How to Test

1. Rebuild the NixOS config on the affected hosts (the user applies via `nixos-rebuild` / `nixos-anywhere`):
   - `nix flake check` on the branch passes and `nix eval` of `k3s-work-01`/`k3s-ctrl-04` succeeds.
2. After applying, restart the storage CSI node daemons so the new host iscsiadm/mount.nfs take effect:
   - `kubectl -n synology-csi rollout restart daemonset synology-csi-node`
   - `kubectl -n kube-system rollout restart daemonset csi-nfs-node`
3. Confirm the affected pods reach Running:
   - `kubectl get pods -n media jellyfin qbittorrent; kubectl get pod -n syncthing syncthing; kubectl get pod -n termix termix; kubectl get pod -n monitoring grafana; kubectl get pod -n coder coder-db-4; kubectl get pod -n life-in-the-uk-quiz life-in-the-uk-quiz-db-3`
4. Confirm no lingering `Multi-Attach`, `Volume[..] is not found`, or `NFS: mount program didn't pass remote address` events:
   - `kubectl get events -A | grep -iE "Multi-Attach|NotFound|remote address"`

## Impact

- **Scope**: All NixOS k3s nodes (currently `k3s-work-01` and `k3s-ctrl-04`) via the shared `nixos/modules/k3s.nix`. No effect on Ubuntu nodes or existing manifests.
- **Risk areas**: The iscsiadm wrapper alters the binary the synology-csi node plugin invokes on NixOS hosts; filtering only drops malformed session lines and preserves the real exit code, so healthy sessions are unaffected. NFS client services (`rpcbind`/`idmapd`/`statd`) are new on NixOS k3s nodes.
- **No PVC/PV data touched.** Stale multi-attach from the drained node had already cleared (node is back `Ready`); no force-detach was required.
- The user still needs to apply the NixOS config to the hosts; this PR only carries the declarative change.
