### PR TITLE
feat(k3s): add k3s-work-02 worker node

### DIFF
--- a/nixos/flake.nix
+++ b/nixos/flake.nix
@@ -106,6 +106,15 @@
       ];
     };
 
+    nixosConfigurations.k3s-work-02 = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      specialArgs = { inherit inputs; inherit sops-secrets; };
+      modules = [
+        ./hosts/k3s-work-02
+        disko.nixosModules.disko
+        sops-nix.nixosModules.sops
+      ];
+    };
     # Matter-server configuration using matterjs-server (matter.js-based implementation)
     # Replaced python-matter-server which was archived and EOL.
     nixosConfigurations.matter-server = nixpkgs.lib.nixosSystem {

--- a/nixos/hosts/k3s-work-02/default.nix
+++ b/nixos/hosts/k3s-work-02/default.nix
@@ -1,0 +1,34 @@
+{ sops-secrets, ... }: {
+  imports = [
+    ../../modules/users.nix
+    ../../modules/hardening.nix
+    ../../modules/k3s.nix
+    ../../modules/disko.nix
+    ../../modules/sops-bootstrap.nix
+  ];
+
+  system.stateVersion = "26.05";
+
+  networking = {
+    hostName = "k3s-work-02";
+    useDHCP = false;
+    usePredictableInterfaceNames = false;
+    interfaces.eth0.ipv4.addresses = [
+      {
+        address = "192.168.1.157";
+        prefixLength = 24;
+      }
+    ];
+    defaultGateway = "192.168.1.1";
+    nameservers = [ "192.168.1.133" "1.1.1.1" "9.9.9.9" ];
+  };
+
+  # secrets — sops-nix decrypts at boot using the shared bootstrap-vm SSH key.
+  sops.defaultSopsFile = "${sops-secrets}/secrets.yaml";
+
+  homelab.k3s = {
+    enable = true;
+    role = "agent";
+    serverAddr = "https://192.168.1.250:6443";
+  };
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -97,4 +97,12 @@ nodes = {
     disk_size = 250
     datastore = "local-lvm"
   }
+  "k3s-work-02" = {
+    node      = "pve04"
+    vm_id     = 106
+    cores     = 8
+    memory    = 8192
+    disk_size = 250
+    datastore = "local-lvm"
+  }
 }


### PR DESCRIPTION
## What

<!-- Brief description of what changed and why. What problem does this solve or what feature are you adding? -->

- Adds k3s-work-02 (VM 106 on pve04, 8 cores / 8 GiB / 250 GB) to the OpenTofu `nodes` map in `terraform/terraform.tfvars`.
- Adds `nixosConfigurations.k3s-work-02` to `nixos/flake.nix` and the new host config at `nixos/hosts/k3s-work-02/default.nix` (static IP 192.168.1.157, k3s agent joining https://192.168.1.250:6443).
- This also fixes the flake pre-build failure in `provision.sh` (`error: Path 'nixos/hosts/k3s-work-02' ... is not tracked by Git`): flakes only see git-tracked files, so the host directory must be committed before nixos-anywhere can build it.

## How to Test

<!-- Steps, commands, or UI actions to verify the change works as expected. -->

1. In `nixos/`: `nix build .#nixosConfigurations.k3s-work-02.config.system.build.toplevel --no-link` — succeeds (verified on this branch; this is the same pre-build provision.sh performs).
2. In `terraform/`: `tofu plan` — shows only the already-tainted `terraform_data.wait_for_guest_ssh["k3s-work-02"]` replacement; no changes to existing nodes.
3. After merge: `tofu apply` provisions the tainted `wait_for_guest_ssh` resource and installs NixOS on k3s-work-02 via nixos-anywhere.

## Impact

<!-- Notes for reviewers: risk areas, things to double-check, trade-offs made. -->

- No changes to existing nodes (pihole-1/2, k3s-ctrl-04, k3s-work-01, haproxy-*, matter-server, hermes-agent are untouched).
- The k3s-work-02 VM (106) already exists on pve04; the NixOS install happens at apply time via the tainted `wait_for_guest_ssh` provisioner — nixos-anywhere/disko will format its disk, which is expected for a fresh VM.