### PR TITLE
fix(iac): guard provision.sh against wiping installed hosts

### DIFF
--- a/docs/runbooks/iac-terraform-opentofu-provisioning.md
+++ b/docs/runbooks/iac-terraform-opentofu-provisioning.md
@@ -215,3 +215,39 @@ pveum aclmod / --token terraform@pam!homelab --role TerraformProv
 ## Use pam Realm, Not pve Realm
 
 Create the Terraform user in the `pam` realm (`terraform@pam`), not `pve` (`terraform@pve`). In Proxmox 8.4, `pve` realm token ACLs are not evaluated correctly, causing persistent 403 errors even with correct ACL entries.
+
+## Troubleshooting
+
+### `kexec_file_load failed: Operation not permitted` / `Kexec failed` from the local-exec provisioner
+
+**Symptom:** `tofu apply` fails on `terraform_data.wait_for_guest_ssh["<host>"]`; the local-exec provisioner output shows nixos-anywhere failing with `kexec_file_load failed: Operation not permitted` or `Kexec failed`.
+
+**Root cause:** The target host is **already installed and running NixOS**, not booted from the installer ISO (the VM uses disk-first `boot_order` and the ISO is detached after install). The installed system imports `nixos/modules/hardening.nix`, which sets `security.protectKernelImage = true` → `kernel.kexec_load_disabled=1`, so the kexec that nixos-anywhere needs is rejected by the kernel. The problem is amplified by a tainted `terraform_data.wait_for_guest_ssh` resource, which re-runs `nixos/scripts/provision.sh` (→ nixos-anywhere → kexec) on every apply.
+
+**Recovery:**
+
+1. Verify the host is actually installed and healthy:
+
+   ```bash
+   ssh root@<ip> 'nixos-rebuild list-generations'
+   ```
+
+2. With the guard in `provision.sh` (skips hosts whose `/` mounts a block device), just re-run `tofu apply` — provisioning is skipped and the tainted resource converges. Alternatively, clear the taint manually:
+
+   ```bash
+   tofu untaint 'terraform_data.wait_for_guest_ssh["<host>"]'
+   ```
+
+**Forced reinstall (destructive):** Boot the VM from the installer ISO, then:
+
+```bash
+tofu taint 'terraform_data.wait_for_guest_ssh["<host>"]' && tofu apply
+```
+
+> **WARNING:** nixos-anywhere wipes the disk via disko. Only do this when you genuinely intend to reinstall the host.
+
+### `error: Path 'nixos/hosts/<name>' in the repository ... is not tracked by Git`
+
+**Symptom:** The flake pre-build in `provision.sh` fails with `error: Path 'nixos/hosts/<name>' in the repository ... is not tracked by Git`.
+
+**Fix:** `git add` the new host directory (e.g. `git add nixos/hosts/<name>`) and commit it. Nix flakes only see git-tracked files, so an untracked host directory is invisible to `nix build`. See also gotcha #1 in [pve-migration-to-nixos.md](pve-migration-to-nixos.md).

--- a/nixos/scripts/provision.sh
+++ b/nixos/scripts/provision.sh
@@ -41,6 +41,26 @@ TARGET_IP="${2:-}"
 [[ -z "$HOSTNAME" ]] && usage
 [[ -z "$TARGET_IP" ]] && usage
 
+# Guard: skip provisioning if the target already boots an installed system.
+# Rationale: nixos-anywhere wipes the disk via disko, and hardened hosts reject
+# kexec anyway (security.protectKernelImage -> kernel.kexec_load_disabled=1 ->
+# "kexec_file_load failed: Operation not permitted"). The tainted
+# terraform_data.wait_for_guest_ssh resource re-runs this script on every apply,
+# so without this guard the apply loops forever (or wipes a production host if
+# it ever boots the ISO).
+# Detection: the installer environment has root on overlay/tmpfs; an installed
+# system has root on a block device (/dev/...).
+# Exit 0 is intentional: it lets the tainted terraform_data resource converge on
+# the next apply instead of failing. If SSH fails (host blank/unreachable), the
+# guard passes through and nixos-anywhere runs as before.
+if ssh -o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new \
+     "root@$TARGET_IP" 'findmnt -n -o SOURCE / | grep -q "^/dev/"' 2>/dev/null; then
+  echo "provision.sh: $HOSTNAME ($TARGET_IP) already boots an installed system - skipping nixos-anywhere."
+  echo "provision.sh: to force a reinstall, boot the VM from the installer ISO, then run:"
+  echo "  tofu taint 'terraform_data.wait_for_guest_ssh[\"$HOSTNAME\"]' && tofu apply"
+  exit 0
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FLAKE_ROOT="$SCRIPT_DIR/.."
 KEYS_DIR="$FLAKE_ROOT/keys"


### PR DESCRIPTION
## What

<!-- Brief description of what changed and why. What problem does this solve or what feature are you adding? -->

- Adds a guard to `nixos/scripts/provision.sh` (after argument parsing, before the flake pre-build) that skips nixos-anywhere when the target already boots an installed system. Detection: the installer environment has `/` on overlay/tmpfs; an installed system has `/` on a block device (`findmnt -n -o SOURCE / | grep -q '^/dev/'`). The guard exits 0 so a tainted `terraform_data.wait_for_guest_ssh` resource converges on the next apply instead of failing; if SSH fails, the guard passes through and provisioning proceeds as before.
- Rationale: nixos-anywhere wipes the disk via disko, and hardened hosts reject kexec anyway (`security.protectKernelImage` → `kernel.kexec_load_disabled=1` → `kexec_file_load failed: Operation not permitted`). A tainted `wait_for_guest_ssh` re-runs this script on every apply — without the guard the apply loops forever, or wipes a production host if it ever boots the ISO.
- Appends a `## Troubleshooting` section to `docs/runbooks/iac-terraform-opentofu-provisioning.md` covering the kexec failure (symptom/root cause/recovery/forced-reinstall warning) and the `not tracked by Git` flake error.

## How to Test

<!-- Steps, commands, or UI actions to verify the change works as expected. -->

1. `bash -n nixos/scripts/provision.sh` — passes.
2. Installed host: `ssh -o BatchMode=yes -o ConnectTimeout=10 root@192.168.1.133 'findmnt -n -o SOURCE /'` → `/dev/sda2` (guard would SKIP). Verified.
3. Installer host: `ssh -o BatchMode=yes -o ConnectTimeout=10 root@192.168.1.128 'findmnt -n -o SOURCE /'` (k3s-work-02, IP from `tofu output temporary_bootstrap_ips`) → `tmpfs` (guard would PROCEED). Verified.

## Impact

<!-- Notes for reviewers: risk areas, things to double-check, trade-offs made. -->

- Already-installed hosts are skipped (exit 0) instead of kexec-failing or being wiped by disko.
- Fresh VMs booted from the installer ISO provision unchanged (root on tmpfs/overlay → guard passes through; also passes through when SSH is unreachable).
- The skip message documents the forced-reinstall path (`tofu taint` + ISO boot), which remains destructive by design.