### PR TITLE
fix(k3s): add /sbin and /usr/sbin to k3s unit PATH for NFS helper

### DIFF
--- a/nixos/modules/k3s.nix
+++ b/nixos/modules/k3s.nix
@@ -105,6 +105,22 @@ in
       tokenFile = config.sops.secrets."k3s-token".path;
     };
 
+    # kubelet mounts in-tree NFS PVs (spec.nfs) by running `mount -t nfs` on the
+    # host, and util-linux resolves the type-specific helper (mount.nfs) from the
+    # k3s unit's PATH. Upstream defaults the k3s unit PATH to only the (usually
+    # unset) zfs package, so the FHS sbin dirs where tmpfiles places mount.nfs
+    # (/sbin, /usr/sbin) are omitted and the helper is never found. The systemd
+    # `path` option appends `/bin` and `/sbin` to each entry, so the entries "/"
+    # and "/usr" here resolve to /bin:/sbin and /usr/bin:/usr/sbin respectively,
+    # injecting exactly those helper directories into the unit's
+    # Environment=PATH=.... Because this changes the unit's Environment=PATH=...,
+    # a later `nixos-rebuild switch` restarts k3s, so the fix activates without
+    # a manual `systemctl restart k3s`.
+    systemd.services.k3s.path = [
+      "/"
+      "/usr"
+    ];
+
     # Synology CSI (iSCSI) attaches need a host-side iscsid + config. The
     # nixpkgs openiscsi module also pulls "iscsi_tcp" into boot.kernelModules
     # (required at boot since hardening locks runtime module loading).
@@ -121,10 +137,11 @@ in
     # nfs4 as supported filesystems: the tasks/filesystems/nfs module then adds
     # nfs-utils to system.fsPackages and starts rpcbind/idmapd/statd. (The older
     # services.nfs.client option no longer exists here.) kubelet already reaches
-    # mount(8) (the failure is at the helper stage), and mount(8) resolves
-    # type-specific helpers from /sbin and /usr/sbin even when those are absent
-    # from its PATH, so the tmpfiles rules below place mount.nfs in those FHS
-    # paths to make in-tree NFS mounts succeed.
+    # mount(8) (the failure is at the helper stage), so the tmpfiles rules below
+    # symlink util-linux's type-specific mount helpers (mount.nfs/mount.nfs4) into
+    # /sbin and /usr/sbin. For kubelet to find them, the k3s unit's PATH must also
+    # include those FHS directories — see the systemd.services.k3s.path override
+    # above.
     boot.supportedFilesystems = [ "nfs" "nfs4" ];
 
     # The synology-csi node plugin runs `chroot /host env iscsiadm ...`; env


### PR DESCRIPTION
## What

kubelet mounts in-tree NFS PVs (`spec.nfs`, e.g. media-pv / qbit-download) by running `mount -t nfs` on the host. The nixpkgs k3s module defaults the k3s unit PATH to only the (usually unset) zfs package, so the FHS `sbin` dirs where `mount.nfs`/`mount.nfs4` symlinks are placed by the module's `systemd.tmpfiles.rules` (`/sbin`, `/usr/sbin`) are absent from the unit PATH. util-linux therefore cannot find the helper and the mount fails with `fsconfig() failed: NFS: mount program didn't pass remote address, exit 32` — until a manual `systemctl restart k3s` re-resolves them.

This PR injects those FHS helper directories into the k3s unit's PATH via `systemd.services.k3s.path`. Because the systemd `path` option appends `/bin` and `/sbin` to each entry, the entries `/` and `/usr` resolve to `/bin`, `/sbin`, `/usr/bin`, `/usr/sbin` — exactly the dirs holding the tmpfiles `mount.nfs` symlinks. Since this changes the unit's `Environment=PATH=...`, a later `nixos-rebuild switch` automatically restarts k3s, making the fix self-healing without a manual restart.

It also corrects a misleading comment that previously claimed `mount(8)` resolves helpers from `/sbin` and `/usr/sbin` even when absent from PATH.

- Adds `systemd.services.k3s.path = [ "/" "/usr" ]` so the k3s unit PATH includes `/sbin` and `/usr/sbin`.
- Corrects the comment describing how the mount helpers are resolved.

## How to Test

1. `cd nixos && nixos-rebuild build --flake .#k3s-work-01` — config builds successfully.
2. After merge, run `./nixos/scripts/rebuild.sh <node> <ip>` on each NixOS k3s node.
3. Verify `systemctl cat k3s` shows `Environment="PATH=...` including `/sbin` and `/usr/sbin`.
4. Verify NFS in-tree PVs (qbittorrent, grimmory) mount without a manual `systemctl restart k3s`.

## Impact

- A brief k3s restart occurs on each node during activation (because the unit content changes).
- NFS in-tree PV mounts become self-healing on future `nixos-rebuild switch` operations.
