### PR TITLE
feat(k3s): open node-exporter port 9100 for prometheus scrape

### DIFF
--- a/nixos/modules/k3s.nix
+++ b/nixos/modules/k3s.nix
@@ -164,7 +164,8 @@ in
         [ 22 ] # ssh (see hardening module)
         ++ [ 6443 ] # Kubernetes API server (server only; harmless on agents)
         ++ (lib.optionals isServer [ 2379 2380 ]) # etcd client/peer (server)
-        ++ [ 10250 ]; # kubelet port required by the metrics server (all nodes must be reachable)
+        ++ [ 10250 ] # kubelet port required by the metrics server (all nodes must be reachable)
+        ++ [ 9100 ]; # node-exporter: Prometheus host scrape (hostNetwork)
       allowedUDPPorts = [ 8472 ]; # Flannel VXLAN overlay (the existing cluster's CNI backend; k3s default)
     };
   };


### PR DESCRIPTION
## What

The three NixOS k3s nodes on pve04 (`k3s-ctrl-04`, `k3s-work-01`, `k3s-work-02`) run the kube-prometheus-stack node-exporter DaemonSet with `hostNetwork: true` (listening on `nodeIP:9100`), but the NixOS host firewall in the shared `nixos/modules/k3s.nix` module never opened TCP `9100`. As a result Prometheus saw these nodes in targets but `up{job="node-exporter"}` was `0` (scrape refused), and all node-exporter metrics (`node_cpu_seconds_total`, etc.) were missing for these hosts in Grafana. The Ubuntu nodes (131/151/152/153) have permissive firewalls, which is why only they were scraped.

This PR adds TCP `9100` to the module's `networking.firewall.allowedTCPPorts` list, which covers all three k3s hosts since they share the module. Also adds a comment noting the port is for Prometheus node-exporter scraping over hostNetwork.

- Adds `9100` to `allowedTCPPorts` in `nixos/modules/k3s.nix`
- Preserves all existing ports (`22`, `6443`, `2379/2380`, `10250`, UDP `8472`) untouched

## How to Test

1. `nix build .#nixosConfigurations.k3s-ctrl-04.config.system.build.toplevel` from `nixos/` — builds cleanly (confirmed; evaluated `allowedTCPPorts` includes `9100`).
2. Rebuilt/activated the three hosts: `./nixos/scripts/rebuild.sh k3s-ctrl-04 192.168.1.154`, `k3s-work-01 192.168.1.156`, `k3s-work-02 192.168.1.157` (all succeeded).
3. Confirm scraping works (after activation):
   - `up{job="node-exporter"}` is now `1` for `192.168.1.154:9100`, `192.168.1.156:9100`, `192.168.1.157:9100` (was `0` before).
   - `node_cpu_seconds_total` is now present for all three instances.
   - Spot check via Prometheus API: `query=up{job="node-exporter"}`.

## Impact

- Low blast radius: adds one TCP port (`9100`) to the host firewall; touches only `allowedTCPPorts` in the shared k3s module. No bootloader/kernel/network changes.
- Exposes node-exporter metrics (hostNetwork) on the k3s nodes to the Prometheus server for scraping, as already intended by the node-exporter DaemonSet.
- Re-applies on future `nixos-rebuild` for all three k3s hosts via the shared module.
